### PR TITLE
v0.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ env:
     - REPO=VirgilSecurity/virgil-cryptowrapper-x
     - REPO_PATH=https://github.com/VirgilSecurity/virgil-cryptowrapper-x.git
   matrix:
-    - DESTINATION=""                                           PREFIX=""         SDK=""              BUILD="0"  PUBLISH_CARTHAGE="YES"  PUBLISH_POD="YES"  PUBLISH_DOCS="YES"
-    - DESTINATION="OS=14.5,name=iPhone 8"                      PREFIX="iOS"      SDK="$IOS_SDK"      BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
-    - DESTINATION="arch=x86_64"                                PREFIX="macOS"    SDK="$MACOS_SDK"    BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
-    - DESTINATION="OS=14.5,name=Apple TV"                      PREFIX="tvOS"     SDK="$TVOS_SDK"     BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
-    - DESTINATION="OS=7.4,name=Apple Watch Series 6 - 40mm"    PREFIX="watchOS"  SDK="$WATCHOS_SDK"  BUILD="1"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION=""                                           PREFIX=""         SDK=""              BUILD="0"  PUBLISH_POD="YES"  PUBLISH_DOCS="YES"
+    - DESTINATION="OS=14.5,name=iPhone 8"                      PREFIX="iOS"      SDK="$IOS_SDK"      BUILD="2"  PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION="arch=x86_64"                                PREFIX="macOS"    SDK="$MACOS_SDK"    BUILD="2"  PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION="OS=14.5,name=Apple TV"                      PREFIX="tvOS"     SDK="$TVOS_SDK"     BUILD="2"  PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION="OS=7.4,name=Apple Watch Series 6 - 40mm"    PREFIX="watchOS"  SDK="$WATCHOS_SDK"  BUILD="1"  PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
 
 before_install:
   - set -e
@@ -44,11 +44,6 @@ script:
       fi
     done
 
-  # Build with carthage
-  - if [ $PUBLISH_CARTHAGE == "YES" ]; then
-      ./CI/publish-carthage.sh;
-    fi
-
   # Generate docs
   - if [[ $PUBLISH_DOCS == "YES" && $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
       ./CI/publish-docs.sh;
@@ -65,16 +60,6 @@ deploy:
       branch: docs-automation
       tags: true
       condition: $PUBLISH_DOCS = "YES" && $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+
-
-  # Publish binary for Carthage
-  - provider: releases
-    api_key: $GITHUB_ACCESS_TOKEN
-    file: "$CRYPTO_FRAMEWORK_NAME.xcframework.zip"
-    skip_cleanup: true
-    on:
-      repo: $REPO
-      tags: true
-      condition: $PUBLISH_CARTHAGE = "YES"
 
   # Publish cocoapods
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
 
   # Build with carthage
   - if [ $PUBLISH_CARTHAGE == "YES" ]; then
-      ./CI/publish-carthage.sh
+      ./CI/publish-carthage.sh;
     fi
 
   # Generate docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   matrix:
     - DESTINATION=""                                           PREFIX=""         SDK=""              BUILD="0"  PUBLISH_CARTHAGE="YES"  PUBLISH_POD="YES"  PUBLISH_DOCS="YES"
     - DESTINATION="OS=14.5,name=iPhone 8"                      PREFIX="iOS"      SDK="$IOS_SDK"      BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
-    - DESTINATION="arch=x86_64"                                PREFIX="macOS"    SDK="$MACOS_SDK"    BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION="platform=OS X"                              PREFIX="macOS"    SDK="$MACOS_SDK"    BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
     - DESTINATION="OS=14.5,name=Apple TV"                      PREFIX="tvOS"     SDK="$TVOS_SDK"     BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
     - DESTINATION="OS=7.4,name=Apple Watch Series 6 - 40mm"    PREFIX="watchOS"  SDK="$WATCHOS_SDK"  BUILD="1"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   matrix:
     - DESTINATION=""                                           PREFIX=""         SDK=""              BUILD="0"  PUBLISH_CARTHAGE="YES"  PUBLISH_POD="YES"  PUBLISH_DOCS="YES"
     - DESTINATION="OS=14.5,name=iPhone 8"                      PREFIX="iOS"      SDK="$IOS_SDK"      BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
-    - DESTINATION="platform=OS X"                              PREFIX="macOS"    SDK="$MACOS_SDK"    BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION="arch=x86_64"                                PREFIX="macOS"    SDK="$MACOS_SDK"    BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
     - DESTINATION="OS=14.5,name=Apple TV"                      PREFIX="tvOS"     SDK="$TVOS_SDK"     BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
     - DESTINATION="OS=7.4,name=Apple Watch Series 6 - 40mm"    PREFIX="watchOS"  SDK="$WATCHOS_SDK"  BUILD="1"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,23 @@
 language: objective-c
-osx_image: xcode11.4
+osx_image: xcode12.5
 
 env:
   global:
     - LC_CTYPE=en_US.UTF-8
     - PROJECT=VirgilCryptoWrapper.xcodeproj
-    - IOS_SDK=iphonesimulator13.4
-    - MACOS_SDK=macosx10.15
-    - TVOS_SDK=appletvsimulator13.4
-    - WATCHOS_SDK=watchsimulator6.2
+    - IOS_SDK=iphonesimulator14.5
+    - MACOS_SDK=macosx11.3
+    - TVOS_SDK=appletvsimulator14.5
+    - WATCHOS_SDK=watchsimulator7.4
     - CRYPTO_FRAMEWORK_NAME=VirgilCryptoWrapper
     - REPO=VirgilSecurity/virgil-cryptowrapper-x
     - REPO_PATH=https://github.com/VirgilSecurity/virgil-cryptowrapper-x.git
   matrix:
     - DESTINATION=""                                           PREFIX=""         SDK=""              BUILD="0"  PUBLISH_CARTHAGE="YES"  PUBLISH_POD="YES"  PUBLISH_DOCS="YES"
-    - DESTINATION="OS=13.4.1,name=iPhone 8"                      PREFIX="iOS"      SDK="$IOS_SDK"      BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION="OS=14.5,name=iPhone 8"                      PREFIX="iOS"      SDK="$IOS_SDK"      BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
     - DESTINATION="arch=x86_64"                                PREFIX="macOS"    SDK="$MACOS_SDK"    BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
-    - DESTINATION="OS=13.4,name=Apple TV 4K"                   PREFIX="tvOS"     SDK="$TVOS_SDK"     BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
-    - DESTINATION="OS=6.2,name=Apple Watch Series 4 - 44mm"    PREFIX="watchOS"  SDK="$WATCHOS_SDK"  BUILD="1"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION="OS=14.5,name=Apple TV 4K"                   PREFIX="tvOS"     SDK="$TVOS_SDK"     BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION="OS=7.4,name=Apple Watch Series 4 - 44mm"    PREFIX="watchOS"  SDK="$WATCHOS_SDK"  BUILD="1"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
 
 before_install:
   - set -e
@@ -25,7 +25,7 @@ before_install:
 
 script:
   - carthage version
-  - carthage bootstrap
+  - carthage bootstrap --use-xcframeworks
 
   - projs=( "VirgilCryptoFoundation" "VirgilCryptoPythia" "VirgilCryptoRatchet" )
 
@@ -46,11 +46,7 @@ script:
 
   # Build with carthage
   - if [ $PUBLISH_CARTHAGE == "YES" ]; then
-      brew update;
-      brew outdated carthage || brew upgrade carthage;
-      carthage build --no-skip-current;
-      carthage archive;
-      mv VirgilCryptoFoundation.framework.zip VirgilCryptoWrapper.framework.zip;
+      ./CI/publish-carthage.sh
     fi
 
   # Generate docs
@@ -73,7 +69,7 @@ deploy:
   # Publish binary for Carthage
   - provider: releases
     api_key: $GITHUB_ACCESS_TOKEN
-    file: "$CRYPTO_FRAMEWORK_NAME.framework.zip"
+    file: "$CRYPTO_FRAMEWORK_NAME.xcframework.zip"
     skip_cleanup: true
     on:
       repo: $REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
     - DESTINATION=""                                           PREFIX=""         SDK=""              BUILD="0"  PUBLISH_CARTHAGE="YES"  PUBLISH_POD="YES"  PUBLISH_DOCS="YES"
     - DESTINATION="OS=14.5,name=iPhone 8"                      PREFIX="iOS"      SDK="$IOS_SDK"      BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
     - DESTINATION="arch=x86_64"                                PREFIX="macOS"    SDK="$MACOS_SDK"    BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
-    - DESTINATION="OS=14.5,name=Apple TV 4K"                   PREFIX="tvOS"     SDK="$TVOS_SDK"     BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
-    - DESTINATION="OS=7.4,name=Apple Watch Series 4 - 44mm"    PREFIX="watchOS"  SDK="$WATCHOS_SDK"  BUILD="1"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION="OS=14.5,name=Apple TV"                      PREFIX="tvOS"     SDK="$TVOS_SDK"     BUILD="2"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
+    - DESTINATION="OS=7.4,name=Apple Watch Series 6 - 40mm"    PREFIX="watchOS"  SDK="$WATCHOS_SDK"  BUILD="1"  PUBLISH_CARTHAGE="NO"   PUBLISH_POD="NO"   PUBLISH_DOCS="NO"
 
 before_install:
   - set -e

--- a/CI/generate-docs-structure.sh
+++ b/CI/generate-docs-structure.sh
@@ -37,11 +37,8 @@
 
 gem install jazzy
 
-# Settings
-INFOPLIST_FILE_PATH="${TRAVIS_BUILD_DIR}/VirgilCryptoFoundation/Info.plist"
-
 # Define SDK versions
-VERSION="v"$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${INFOPLIST_FILE_PATH}")
+VERSION="v"$(xcodebuild -showBuildSettings | grep MARKETING_VERSION | tr -d 'MARKETING_VERSION =')
 CURRENT_VERSION_DIR="${DOCS_DIR}/${VERSION}"
 mkdir "${CURRENT_VERSION_DIR}"
 

--- a/CI/publish-carthage.sh
+++ b/CI/publish-carthage.sh
@@ -4,6 +4,7 @@ brew update;
 brew outdated carthage || brew upgrade carthage;
 carthage build --use-xcframeworks --no-skip-current;
 
+# TODO: Should be replaced by carthage archive, when it supports xcframeworks
 rm -r ${FRAMEWORKS_PATH}/VSCCommon.xcframework ${FRAMEWORKS_PATH}/VSCFoundation.xcframework ${FRAMEWORKS_PATH}/VSCPythia.xcframework ${FRAMEWORKS_PATH}/VSCRatchet.xcframework Carthage/Checkouts
 
 zip -r VirgilCryptoWrapper.xcframework.zip Carthage

--- a/CI/publish-carthage.sh
+++ b/CI/publish-carthage.sh
@@ -1,6 +1,6 @@
-#brew update;
-#brew outdated carthage || brew upgrade carthage;
-#carthage build --use-xcframeworks --no-skip-current;
+brew update;
+brew outdated carthage || brew upgrade carthage;
+carthage build --use-xcframeworks --no-skip-current;
 
 # TODO: Should be replaced by carthage archive, when it supports xcframeworks
 FRAMEWORKS_PATH=Carthage/Build

--- a/CI/publish-carthage.sh
+++ b/CI/publish-carthage.sh
@@ -1,10 +1,8 @@
-FRAMEWORKS_PATH=Carthage/Build
-
-brew update;
-brew outdated carthage || brew upgrade carthage;
-carthage build --use-xcframeworks --no-skip-current;
+#brew update;
+#brew outdated carthage || brew upgrade carthage;
+#carthage build --use-xcframeworks --no-skip-current;
 
 # TODO: Should be replaced by carthage archive, when it supports xcframeworks
-rm -r ${FRAMEWORKS_PATH}/VSCCommon.xcframework ${FRAMEWORKS_PATH}/VSCFoundation.xcframework ${FRAMEWORKS_PATH}/VSCPythia.xcframework ${FRAMEWORKS_PATH}/VSCRatchet.xcframework Carthage/Checkouts
-
-zip -r VirgilCryptoWrapper.xcframework.zip Carthage
+FRAMEWORKS_PATH=Carthage/Build
+find ${FRAMEWORKS_PATH} ! -name 'VirgilCrypto*' -delete
+zip -r VirgilCryptoWrapper.xcframework.zip ${FRAMEWORKS_PATH}

--- a/CI/publish-carthage.sh
+++ b/CI/publish-carthage.sh
@@ -1,0 +1,9 @@
+FRAMEWORKS_PATH=Carthage/Build
+
+brew update;
+brew outdated carthage || brew upgrade carthage;
+carthage build --use-xcframeworks --no-skip-current;
+
+rm -r ${FRAMEWORKS_PATH}/VSCCommon.xcframework ${FRAMEWORKS_PATH}/VSCFoundation.xcframework ${FRAMEWORKS_PATH}/VSCPythia.xcframework ${FRAMEWORKS_PATH}/VSCRatchet.xcframework Carthage/Checkouts
+
+zip -r VirgilCryptoWrapper.xcframework.zip Carthage

--- a/CI/publish-cocoapods.sh
+++ b/CI/publish-cocoapods.sh
@@ -1,4 +1,9 @@
 pod trunk push VirgilCryptoFoundation.podspec;
+
+rm -fr ~/.cocoapods/repos;
+rm -fr ~/Library/Caches/CocoaPods/;
+pod setup;
 pod repo update;
+
 pod trunk push VirgilCryptoPythia.podspec;
 pod trunk push VirgilCryptoRatchet.podspec;

--- a/CI/publish-cocoapods.sh
+++ b/CI/publish-cocoapods.sh
@@ -1,9 +1,1 @@
 pod trunk push VirgilCryptoFoundation.podspec;
-
-rm -fr ~/.cocoapods/repos;
-rm -fr ~/Library/Caches/CocoaPods/;
-pod setup;
-pod repo update;
-
-pod trunk push VirgilCryptoPythia.podspec;
-pod trunk push VirgilCryptoRatchet.podspec;

--- a/CI/publish-cocoapods.sh
+++ b/CI/publish-cocoapods.sh
@@ -1,4 +1,4 @@
 pod trunk push VirgilCryptoFoundation.podspec;
-pod repo update master;
+pod repo update;
 pod trunk push VirgilCryptoPythia.podspec;
 pod trunk push VirgilCryptoRatchet.podspec;

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "VirgilSecurity/virgil-crypto-c" "v0.16.0-beta1"
+github "VirgilSecurity/virgil-crypto-c" "v0.16.0-rc1"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "VirgilSecurity/virgil-crypto-c" "v0.15.2"
+github "VirgilSecurity/virgil-crypto-c" "v0.16.0-beta1"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "VirgilSecurity/virgil-crypto-c" "v0.16.0-rc1"
+github "VirgilSecurity/virgil-crypto-c" "v0.16.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "VirgilSecurity/virgil-crypto-c" "v0.16.0-beta1"
+github "VirgilSecurity/virgil-crypto-c" "v0.16.0-rc1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "VirgilSecurity/virgil-crypto-c" "v0.15.2"
+github "VirgilSecurity/virgil-crypto-c" "v0.16.0-beta1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "VirgilSecurity/virgil-crypto-c" "v0.16.0-rc1"
+github "VirgilSecurity/virgil-crypto-c" "v0.16.0"

--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -1,0 +1,11 @@
+//
+//  Config.xcconfig
+//  VirgilCryptoWrapper
+//
+//  Created by Yevhen Pyvovarov on 13.07.2021.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+MARKETING_VERSION = 0.16.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,33 @@
-BSD 3-Clause License
+Copyright (C) 2015-2021 Virgil Security, Inc.
 
-Copyright (c) 2019, Virgil Security, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+modification, are permitted provided that the following conditions are
+met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+    (1) Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+    (2) Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
 
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
+    (3) Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+Lead Maintainer: Virgil Security Inc. <support@virgilsecurity.com>

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ To integrate VirgilCryptoWrapper into your Xcode project using CocoaPods, specif
 target '<Your Target Name>' do
   use_frameworks!
 
-  pod 'VirgilCryptoFoundation', '~> 0.16.0'
-  pod 'VirgilCryptoRatchet', '~> 0.16.0'
-  pod 'VirgilCryptoPythia', '~> 0.16.0'
+  pod 'VirgilCryptoFoundation', '~> 0.16.0-rc1'
+  pod 'VirgilCryptoRatchet', '~> 0.16.0-rc1'
+  pod 'VirgilCryptoPythia', '~> 0.16.0-rc1'
 end
 ```
 
@@ -93,7 +93,7 @@ $ brew install carthage
 To integrate VirgilCryptoWrapper into your Xcode project using Carthage, create an empty file with name *Cartfile* in your project's root folder and add following lines to your *Cartfile*
 
 ```
-github "VirgilSecurity/virgil-cryptowrapper-x" ~> 0.16.0
+github "VirgilSecurity/virgil-cryptowrapper-x" ~> 0.16.0-rc1
 ```
 
 #### Linking against prebuilt binaries

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ To integrate VirgilCryptoWrapper into your Xcode project using CocoaPods, specif
 target '<Your Target Name>' do
   use_frameworks!
 
-  pod 'VirgilCryptoFoundation', '~> 0.16.0-rc1'
-  pod 'VirgilCryptoRatchet', '~> 0.16.0-rc1'
-  pod 'VirgilCryptoPythia', '~> 0.16.0-rc1'
+  pod 'VirgilCryptoFoundation', '~> 0.16.0'
+  pod 'VirgilCryptoRatchet', '~> 0.16.0'
+  pod 'VirgilCryptoPythia', '~> 0.16.0'
 end
 ```
 
@@ -93,7 +93,7 @@ $ brew install carthage
 To integrate VirgilCryptoWrapper into your Xcode project using Carthage, create an empty file with name *Cartfile* in your project's root folder and add following lines to your *Cartfile*
 
 ```
-github "VirgilSecurity/virgil-cryptowrapper-x" ~> 0.16.0-rc1
+github "VirgilSecurity/virgil-cryptowrapper-x" ~> 0.16.0
 ```
 
 #### Linking against prebuilt binaries

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ To integrate VirgilCryptoWrapper into your Xcode project using CocoaPods, specif
 target '<Your Target Name>' do
   use_frameworks!
 
-  pod 'VirgilCryptoFoundation', '~> 0.15.2'
-  pod 'VirgilCryptoRatchet', '~> 0.15.2'
-  pod 'VirgilCryptoPythia', '~> 0.15.2'
+  pod 'VirgilCryptoFoundation', '~> 0.16.0'
+  pod 'VirgilCryptoRatchet', '~> 0.16.0'
+  pod 'VirgilCryptoPythia', '~> 0.16.0'
 end
 ```
 
@@ -93,7 +93,7 @@ $ brew install carthage
 To integrate VirgilCryptoWrapper into your Xcode project using Carthage, create an empty file with name *Cartfile* in your project's root folder and add following lines to your *Cartfile*
 
 ```
-github "VirgilSecurity/virgil-cryptowrapper-x" ~> 0.15.2
+github "VirgilSecurity/virgil-cryptowrapper-x" ~> 0.16.0
 ```
 
 #### Linking against prebuilt binaries
@@ -101,8 +101,9 @@ github "VirgilSecurity/virgil-cryptowrapper-x" ~> 0.15.2
 To link prebuilt frameworks to your app, run following command:
 
 ```bash
-$ carthage update
+$ carthage update --use-xcframeworks
 ```
+
 
 This will build each dependency or download a pre-compiled framework from github Releases.
 
@@ -117,25 +118,7 @@ On your application target's “General” settings tab, in the “Linked Framew
  - VSCRatchet
  - VSCPythia
  
- __NOTE__: It's not mandatory to include all this dependencies, add only frameworks you are going to use. Frameworks with VSC prefix in their name are written in C, those without prefix are swift frameworks. It is mandatory to include VSCCommon and for any VirgilCryptoNAME.framework add also VSCNAME.framework. 
-
-On your application target's “Build Phases” settings tab, click the “+” icon and choose “New Run Script Phase”. Create a Run Script in which you specify your shell (ex: */bin/sh*), add the following contents to the script area below the shell:
-
-```bash
-/usr/local/bin/carthage copy-frameworks
-```
-
-and add the paths to the frameworks you want to use under “Input Files”, e.g.:
-
-```
-$(SRCROOT)/Carthage/Build/iOS/VirgilCryptoFoundation.framework
-$(SRCROOT)/Carthage/Build/iOS/VirgilCryptoRatchet.framework
-$(SRCROOT)/Carthage/Build/iOS/VirgilCryptoPythia.framework
-$(SRCROOT)/Carthage/Build/iOS/VSCCommon.framework
-$(SRCROOT)/Carthage/Build/iOS/VSCFoundation.framework
-$(SRCROOT)/Carthage/Build/iOS/VSCRatchet.framework
-$(SRCROOT)/Carthage/Build/iOS/VSCPythia.framework
-```
+ Check Embed & sign for each.
 
 ##### Building for macOS
 

--- a/VirgilCryptoFoundation.podspec
+++ b/VirgilCryptoFoundation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "VirgilCryptoFoundation"
-  s.version                     = "0.16.0"
+  s.version                     = "0.16.0-rc1"
   s.swift_version               = "5.0"
   s.license                     = { :type => "BSD", :file => "LICENSE" }
   s.summary                     = "Contains basic swift classes for creating key pairs, encrypting/decrypting data, signing data and verifying signatures."
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target   = "2.0"
   s.public_header_files         = "VirgilCryptoFoundation/VirgilCryptoFoundation.h"
   s.source_files                = "VirgilCryptoFoundation/**/*.{h,mm,swift}"
-  s.dependency 'VSCCrypto/Common', '= 0.16.0-beta1'
-  s.dependency 'VSCCrypto/Foundation', '= 0.16.0-beta1'
+  s.dependency 'VSCCrypto/Common', '= 0.16.0-rc1'
+  s.dependency 'VSCCrypto/Foundation', '= 0.16.0-rc1'
 end

--- a/VirgilCryptoFoundation.podspec
+++ b/VirgilCryptoFoundation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "VirgilCryptoFoundation"
-  s.version                     = "0.15.2"
+  s.version                     = "0.16.0"
   s.swift_version               = "5.0"
   s.license                     = { :type => "BSD", :file => "LICENSE" }
   s.summary                     = "Contains basic swift classes for creating key pairs, encrypting/decrypting data, signing data and verifying signatures."
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target   = "2.0"
   s.public_header_files         = "VirgilCryptoFoundation/VirgilCryptoFoundation.h"
   s.source_files                = "VirgilCryptoFoundation/**/*.{h,mm,swift}"
-  s.dependency 'VSCCrypto/Common', '= 0.15.2'
-  s.dependency 'VSCCrypto/Foundation', '= 0.15.2'
+  s.dependency 'VSCCrypto/Common', '= 0.16.0-beta1'
+  s.dependency 'VSCCrypto/Foundation', '= 0.16.0-beta1'
 end

--- a/VirgilCryptoFoundation.podspec
+++ b/VirgilCryptoFoundation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "VirgilCryptoFoundation"
-  s.version                     = "0.16.0-rc1"
+  s.version                     = "0.16.0"
   s.swift_version               = "5.0"
   s.license                     = { :type => "BSD", :file => "LICENSE" }
   s.summary                     = "Contains basic swift classes for creating key pairs, encrypting/decrypting data, signing data and verifying signatures."
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target   = "2.0"
   s.public_header_files         = "VirgilCryptoFoundation/VirgilCryptoFoundation.h"
   s.source_files                = "VirgilCryptoFoundation/**/*.{h,mm,swift}"
-  s.dependency 'VSCCrypto/Common', '= 0.16.0-rc1'
-  s.dependency 'VSCCrypto/Foundation', '= 0.16.0-rc1'
+  s.dependency 'VSCCrypto/Common', '= 0.16.0'
+  s.dependency 'VSCCrypto/Foundation', '= 0.16.0'
 end

--- a/VirgilCryptoFoundation/Aes256Cbc.swift
+++ b/VirgilCryptoFoundation/Aes256Cbc.swift
@@ -106,7 +106,7 @@ import VSCFoundation
     @objc public func encrypt(data: Data) throws -> Data {
         let outCount = self.encryptedLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -143,7 +143,7 @@ import VSCFoundation
     @objc public func decrypt(data: Data) throws -> Data {
         let outCount = self.decryptedLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -199,7 +199,7 @@ import VSCFoundation
     @objc public func update(data: Data) -> Data {
         let outCount = self.outLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -247,7 +247,7 @@ import VSCFoundation
     @objc public func finish() throws -> Data {
         let outCount = self.outLen(dataLen: 0)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/Aes256Cbc.swift
+++ b/VirgilCryptoFoundation/Aes256Cbc.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Aes256Gcm.swift
+++ b/VirgilCryptoFoundation/Aes256Gcm.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Aes256Gcm.swift
+++ b/VirgilCryptoFoundation/Aes256Gcm.swift
@@ -109,7 +109,7 @@ import VSCFoundation
     @objc public func encrypt(data: Data) throws -> Data {
         let outCount = self.encryptedLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -146,7 +146,7 @@ import VSCFoundation
     @objc public func decrypt(data: Data) throws -> Data {
         let outCount = self.decryptedLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -202,7 +202,7 @@ import VSCFoundation
     @objc public func update(data: Data) -> Data {
         let outCount = self.outLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -250,7 +250,7 @@ import VSCFoundation
     @objc public func finish() throws -> Data {
         let outCount = self.outLen(dataLen: 0)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -272,14 +272,14 @@ import VSCFoundation
     @objc public func authEncrypt(data: Data, authData: Data) throws -> AuthEncryptAuthEncryptResult {
         let outCount = self.authEncryptedLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
 
         let tagCount = self.authTagLen
         var tag = Data(count: tagCount)
-        var tagBuf = vsc_buffer_new()
+        let tagBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(tagBuf)
         }
@@ -317,7 +317,7 @@ import VSCFoundation
     @objc public func authDecrypt(data: Data, authData: Data, tag: Data) throws -> Data {
         let outCount = self.authDecryptedLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -362,14 +362,14 @@ import VSCFoundation
     @objc public func finishAuthEncryption() throws -> CipherAuthFinishAuthEncryptionResult {
         let outCount = self.outLen(dataLen: 0)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
 
         let tagCount = self.authTagLen
         var tag = Data(count: tagCount)
-        var tagBuf = vsc_buffer_new()
+        let tagBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(tagBuf)
         }
@@ -398,7 +398,7 @@ import VSCFoundation
     @objc public func finishAuthDecryption(tag: Data) throws -> Data {
         let outCount = self.outLen(dataLen: 0)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/Alg.swift
+++ b/VirgilCryptoFoundation/Alg.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/AlgFactory.swift
+++ b/VirgilCryptoFoundation/AlgFactory.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/AlgId.swift
+++ b/VirgilCryptoFoundation/AlgId.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/AlgInfo.swift
+++ b/VirgilCryptoFoundation/AlgInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/AlgInfoDerDeserializer.swift
+++ b/VirgilCryptoFoundation/AlgInfoDerDeserializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/AlgInfoDerSerializer.swift
+++ b/VirgilCryptoFoundation/AlgInfoDerSerializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/AlgInfoDerSerializer.swift
+++ b/VirgilCryptoFoundation/AlgInfoDerSerializer.swift
@@ -97,7 +97,7 @@ import VSCFoundation
     @objc public func serialize(algInfo: AlgInfo) -> Data {
         let outCount = self.serializedLen(algInfo: algInfo)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/AlgInfoDeserializer.swift
+++ b/VirgilCryptoFoundation/AlgInfoDeserializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/AlgInfoSerializer.swift
+++ b/VirgilCryptoFoundation/AlgInfoSerializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Asn1Reader.swift
+++ b/VirgilCryptoFoundation/Asn1Reader.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Asn1Tag.swift
+++ b/VirgilCryptoFoundation/Asn1Tag.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Asn1Writer.swift
+++ b/VirgilCryptoFoundation/Asn1Writer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Asn1rd.swift
+++ b/VirgilCryptoFoundation/Asn1rd.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Asn1wr.swift
+++ b/VirgilCryptoFoundation/Asn1wr.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/AuthDecrypt.swift
+++ b/VirgilCryptoFoundation/AuthDecrypt.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/AuthEncrypt.swift
+++ b/VirgilCryptoFoundation/AuthEncrypt.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Base64.swift
+++ b/VirgilCryptoFoundation/Base64.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Base64.swift
+++ b/VirgilCryptoFoundation/Base64.swift
@@ -51,7 +51,7 @@ import VSCFoundation
     @objc public static func encode(data: Data) -> Data {
         let strCount = Base64.encodedLen(dataLen: data.count)
         var str = Data(count: strCount)
-        var strBuf = vsc_buffer_new()
+        let strBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(strBuf)
         }
@@ -79,7 +79,7 @@ import VSCFoundation
     @objc public static func decode(str: Data) throws -> Data {
         let dataCount = Base64.decodedLen(strLen: str.count)
         var data = Data(count: dataCount)
-        var dataBuf = vsc_buffer_new()
+        let dataBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(dataBuf)
         }

--- a/VirgilCryptoFoundation/BrainkeyClient.swift
+++ b/VirgilCryptoFoundation/BrainkeyClient.swift
@@ -93,14 +93,14 @@ import VSCFoundation
     @objc public func blind(password: Data) throws -> BrainkeyClientBlindResult {
         let deblindFactorCount = BrainkeyClient.mpiLen
         var deblindFactor = Data(count: deblindFactorCount)
-        var deblindFactorBuf = vsc_buffer_new()
+        let deblindFactorBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(deblindFactorBuf)
         }
 
         let blindedPointCount = BrainkeyClient.pointLen
         var blindedPoint = Data(count: blindedPointCount)
-        var blindedPointBuf = vsc_buffer_new()
+        let blindedPointBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(blindedPointBuf)
         }
@@ -127,7 +127,7 @@ import VSCFoundation
     @objc public func deblind(password: Data, hardenedPoint: Data, deblindFactor: Data, keyName: Data) throws -> Data {
         let seedCount = BrainkeyClient.pointLen
         var seed = Data(count: seedCount)
-        var seedBuf = vsc_buffer_new()
+        let seedBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(seedBuf)
         }

--- a/VirgilCryptoFoundation/BrainkeyClient.swift
+++ b/VirgilCryptoFoundation/BrainkeyClient.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/BrainkeyServer.swift
+++ b/VirgilCryptoFoundation/BrainkeyServer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/BrainkeyServer.swift
+++ b/VirgilCryptoFoundation/BrainkeyServer.swift
@@ -90,7 +90,7 @@ import VSCFoundation
     @objc public func generateIdentitySecret() throws -> Data {
         let identitySecretCount = BrainkeyServer.mpiLen
         var identitySecret = Data(count: identitySecretCount)
-        var identitySecretBuf = vsc_buffer_new()
+        let identitySecretBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(identitySecretBuf)
         }
@@ -110,7 +110,7 @@ import VSCFoundation
     @objc public func harden(identitySecret: Data, blindedPoint: Data) throws -> Data {
         let hardenedPointCount = BrainkeyServer.pointLen
         var hardenedPoint = Data(count: hardenedPointCount)
-        var hardenedPointBuf = vsc_buffer_new()
+        let hardenedPointBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(hardenedPointBuf)
         }

--- a/VirgilCryptoFoundation/CContext.swift
+++ b/VirgilCryptoFoundation/CContext.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Cipher.swift
+++ b/VirgilCryptoFoundation/Cipher.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CipherAlgInfo.swift
+++ b/VirgilCryptoFoundation/CipherAlgInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CipherAuth.swift
+++ b/VirgilCryptoFoundation/CipherAuth.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CipherAuthInfo.swift
+++ b/VirgilCryptoFoundation/CipherAuthInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CipherInfo.swift
+++ b/VirgilCryptoFoundation/CipherInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CipherState.swift
+++ b/VirgilCryptoFoundation/CipherState.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CompoundKeyAlg.swift
+++ b/VirgilCryptoFoundation/CompoundKeyAlg.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CompoundKeyAlg.swift
+++ b/VirgilCryptoFoundation/CompoundKeyAlg.swift
@@ -230,7 +230,7 @@ import VSCFoundation
     @objc public func encrypt(publicKey: PublicKey, data: Data) throws -> Data {
         let outCount = self.encryptedLen(publicKey: publicKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -268,7 +268,7 @@ import VSCFoundation
     @objc public func decrypt(privateKey: PrivateKey, data: Data) throws -> Data {
         let outCount = self.decryptedLen(privateKey: privateKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -306,7 +306,7 @@ import VSCFoundation
     @objc public func signHash(privateKey: PrivateKey, hashId: AlgId, digest: Data) throws -> Data {
         let signatureCount = self.signatureLen(privateKey: privateKey)
         var signature = Data(count: signatureCount)
-        var signatureBuf = vsc_buffer_new()
+        let signatureBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(signatureBuf)
         }

--- a/VirgilCryptoFoundation/CompoundKeyAlgInfo.swift
+++ b/VirgilCryptoFoundation/CompoundKeyAlgInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CompoundPrivateKey.swift
+++ b/VirgilCryptoFoundation/CompoundPrivateKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CompoundPublicKey.swift
+++ b/VirgilCryptoFoundation/CompoundPublicKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/ComputeSharedKey.swift
+++ b/VirgilCryptoFoundation/ComputeSharedKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CtrDrbg.swift
+++ b/VirgilCryptoFoundation/CtrDrbg.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/CtrDrbg.swift
+++ b/VirgilCryptoFoundation/CtrDrbg.swift
@@ -111,7 +111,7 @@ import VSCFoundation
     @objc public func random(dataLen: Int) throws -> Data {
         let dataCount = dataLen
         var data = Data(count: dataCount)
-        var dataBuf = vsc_buffer_new()
+        let dataBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(dataBuf)
         }

--- a/VirgilCryptoFoundation/Curve25519.swift
+++ b/VirgilCryptoFoundation/Curve25519.swift
@@ -210,7 +210,7 @@ import VSCFoundation
     @objc public func encrypt(publicKey: PublicKey, data: Data) throws -> Data {
         let outCount = self.encryptedLen(publicKey: publicKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -248,7 +248,7 @@ import VSCFoundation
     @objc public func decrypt(privateKey: PrivateKey, data: Data) throws -> Data {
         let outCount = self.decryptedLen(privateKey: privateKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -272,7 +272,7 @@ import VSCFoundation
     @objc public func computeSharedKey(publicKey: PublicKey, privateKey: PrivateKey) throws -> Data {
         let sharedKeyCount = self.sharedKeyLen(key: privateKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }
@@ -315,14 +315,14 @@ import VSCFoundation
     @objc public func kemEncapsulate(publicKey: PublicKey) throws -> KemKemEncapsulateResult {
         let sharedKeyCount = self.kemSharedKeyLen(key: publicKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }
 
         let encapsulatedKeyCount = self.kemEncapsulatedKeyLen(publicKey: publicKey)
         var encapsulatedKey = Data(count: encapsulatedKeyCount)
-        var encapsulatedKeyBuf = vsc_buffer_new()
+        let encapsulatedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(encapsulatedKeyBuf)
         }
@@ -348,7 +348,7 @@ import VSCFoundation
     @objc public func kemDecapsulate(encapsulatedKey: Data, privateKey: PrivateKey) throws -> Data {
         let sharedKeyCount = self.kemSharedKeyLen(key: privateKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }

--- a/VirgilCryptoFoundation/Curve25519.swift
+++ b/VirgilCryptoFoundation/Curve25519.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Decrypt.swift
+++ b/VirgilCryptoFoundation/Decrypt.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Ecc.swift
+++ b/VirgilCryptoFoundation/Ecc.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Ecc.swift
+++ b/VirgilCryptoFoundation/Ecc.swift
@@ -215,7 +215,7 @@ import VSCFoundation
     @objc public func encrypt(publicKey: PublicKey, data: Data) throws -> Data {
         let outCount = self.encryptedLen(publicKey: publicKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -253,7 +253,7 @@ import VSCFoundation
     @objc public func decrypt(privateKey: PrivateKey, data: Data) throws -> Data {
         let outCount = self.decryptedLen(privateKey: privateKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -291,7 +291,7 @@ import VSCFoundation
     @objc public func signHash(privateKey: PrivateKey, hashId: AlgId, digest: Data) throws -> Data {
         let signatureCount = self.signatureLen(privateKey: privateKey)
         var signature = Data(count: signatureCount)
-        var signatureBuf = vsc_buffer_new()
+        let signatureBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(signatureBuf)
         }
@@ -334,7 +334,7 @@ import VSCFoundation
     @objc public func computeSharedKey(publicKey: PublicKey, privateKey: PrivateKey) throws -> Data {
         let sharedKeyCount = self.sharedKeyLen(key: privateKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }
@@ -377,14 +377,14 @@ import VSCFoundation
     @objc public func kemEncapsulate(publicKey: PublicKey) throws -> KemKemEncapsulateResult {
         let sharedKeyCount = self.kemSharedKeyLen(key: publicKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }
 
         let encapsulatedKeyCount = self.kemEncapsulatedKeyLen(publicKey: publicKey)
         var encapsulatedKey = Data(count: encapsulatedKeyCount)
-        var encapsulatedKeyBuf = vsc_buffer_new()
+        let encapsulatedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(encapsulatedKeyBuf)
         }
@@ -410,7 +410,7 @@ import VSCFoundation
     @objc public func kemDecapsulate(encapsulatedKey: Data, privateKey: PrivateKey) throws -> Data {
         let sharedKeyCount = self.kemSharedKeyLen(key: privateKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }

--- a/VirgilCryptoFoundation/EccAlgInfo.swift
+++ b/VirgilCryptoFoundation/EccAlgInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/EccPrivateKey.swift
+++ b/VirgilCryptoFoundation/EccPrivateKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/EccPublicKey.swift
+++ b/VirgilCryptoFoundation/EccPublicKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Ecies.swift
+++ b/VirgilCryptoFoundation/Ecies.swift
@@ -130,7 +130,7 @@ import VSCFoundation
     @objc public func encrypt(publicKey: PublicKey, data: Data) throws -> Data {
         let outCount = self.encryptedLen(publicKey: publicKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -160,7 +160,7 @@ import VSCFoundation
     @objc public func decrypt(privateKey: PrivateKey, data: Data) throws -> Data {
         let outCount = self.decryptedLen(privateKey: privateKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/Ecies.swift
+++ b/VirgilCryptoFoundation/Ecies.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Ed25519.swift
+++ b/VirgilCryptoFoundation/Ed25519.swift
@@ -210,7 +210,7 @@ import VSCFoundation
     @objc public func encrypt(publicKey: PublicKey, data: Data) throws -> Data {
         let outCount = self.encryptedLen(publicKey: publicKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -248,7 +248,7 @@ import VSCFoundation
     @objc public func decrypt(privateKey: PrivateKey, data: Data) throws -> Data {
         let outCount = self.decryptedLen(privateKey: privateKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -286,7 +286,7 @@ import VSCFoundation
     @objc public func signHash(privateKey: PrivateKey, hashId: AlgId, digest: Data) throws -> Data {
         let signatureCount = self.signatureLen(privateKey: privateKey)
         var signature = Data(count: signatureCount)
-        var signatureBuf = vsc_buffer_new()
+        let signatureBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(signatureBuf)
         }
@@ -329,7 +329,7 @@ import VSCFoundation
     @objc public func computeSharedKey(publicKey: PublicKey, privateKey: PrivateKey) throws -> Data {
         let sharedKeyCount = self.sharedKeyLen(key: privateKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }
@@ -372,14 +372,14 @@ import VSCFoundation
     @objc public func kemEncapsulate(publicKey: PublicKey) throws -> KemKemEncapsulateResult {
         let sharedKeyCount = self.kemSharedKeyLen(key: publicKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }
 
         let encapsulatedKeyCount = self.kemEncapsulatedKeyLen(publicKey: publicKey)
         var encapsulatedKey = Data(count: encapsulatedKeyCount)
-        var encapsulatedKeyBuf = vsc_buffer_new()
+        let encapsulatedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(encapsulatedKeyBuf)
         }
@@ -405,7 +405,7 @@ import VSCFoundation
     @objc public func kemDecapsulate(encapsulatedKey: Data, privateKey: PrivateKey) throws -> Data {
         let sharedKeyCount = self.kemSharedKeyLen(key: privateKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }

--- a/VirgilCryptoFoundation/Ed25519.swift
+++ b/VirgilCryptoFoundation/Ed25519.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Encrypt.swift
+++ b/VirgilCryptoFoundation/Encrypt.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/EntropyAccumulator.swift
+++ b/VirgilCryptoFoundation/EntropyAccumulator.swift
@@ -92,7 +92,7 @@ import VSCFoundation
     @objc public func gather(len: Int) throws -> Data {
         let outCount = len
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/EntropyAccumulator.swift
+++ b/VirgilCryptoFoundation/EntropyAccumulator.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/EntropySource.swift
+++ b/VirgilCryptoFoundation/EntropySource.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/FakeRandom.swift
+++ b/VirgilCryptoFoundation/FakeRandom.swift
@@ -86,7 +86,7 @@ import VSCFoundation
     @objc public func random(dataLen: Int) throws -> Data {
         let dataCount = dataLen
         var data = Data(count: dataCount)
-        var dataBuf = vsc_buffer_new()
+        let dataBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(dataBuf)
         }
@@ -121,7 +121,7 @@ import VSCFoundation
     @objc public func gather(len: Int) throws -> Data {
         let outCount = len
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/FakeRandom.swift
+++ b/VirgilCryptoFoundation/FakeRandom.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Falcon.swift
+++ b/VirgilCryptoFoundation/Falcon.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Falcon.swift
+++ b/VirgilCryptoFoundation/Falcon.swift
@@ -228,7 +228,7 @@ import VSCFoundation
     @objc public func signHash(privateKey: PrivateKey, hashId: AlgId, digest: Data) throws -> Data {
         let signatureCount = self.signatureLen(privateKey: privateKey)
         var signature = Data(count: signatureCount)
-        var signatureBuf = vsc_buffer_new()
+        let signatureBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(signatureBuf)
         }

--- a/VirgilCryptoFoundation/FooterInfo.swift
+++ b/VirgilCryptoFoundation/FooterInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/FoundationError.swift
+++ b/VirgilCryptoFoundation/FoundationError.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/FoundationImplementation.swift
+++ b/VirgilCryptoFoundation/FoundationImplementation.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/GroupMsgType.swift
+++ b/VirgilCryptoFoundation/GroupMsgType.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/GroupSession.swift
+++ b/VirgilCryptoFoundation/GroupSession.swift
@@ -138,7 +138,7 @@ import VSCFoundation
     @objc public func decrypt(message: GroupSessionMessage, publicKey: PublicKey) throws -> Data {
         let plainTextCount = self.decryptLen(message: message)
         var plainText = Data(count: plainTextCount)
-        var plainTextBuf = vsc_buffer_new()
+        let plainTextBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(plainTextBuf)
         }

--- a/VirgilCryptoFoundation/GroupSession.swift
+++ b/VirgilCryptoFoundation/GroupSession.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/GroupSessionMessage.swift
+++ b/VirgilCryptoFoundation/GroupSessionMessage.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/GroupSessionMessage.swift
+++ b/VirgilCryptoFoundation/GroupSessionMessage.swift
@@ -105,7 +105,7 @@ import VSCFoundation
     @objc public func serialize() -> Data {
         let outputCount = self.serializeLen()
         var output = Data(count: outputCount)
-        var outputBuf = vsc_buffer_new()
+        let outputBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outputBuf)
         }

--- a/VirgilCryptoFoundation/GroupSessionTicket.swift
+++ b/VirgilCryptoFoundation/GroupSessionTicket.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Hash.swift
+++ b/VirgilCryptoFoundation/Hash.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/HashBasedAlgInfo.swift
+++ b/VirgilCryptoFoundation/HashBasedAlgInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Hkdf.swift
+++ b/VirgilCryptoFoundation/Hkdf.swift
@@ -97,7 +97,7 @@ import VSCFoundation
     @objc public func derive(data: Data, keyLen: Int) -> Data {
         let keyCount = keyLen
         var key = Data(count: keyCount)
-        var keyBuf = vsc_buffer_new()
+        let keyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(keyBuf)
         }

--- a/VirgilCryptoFoundation/Hkdf.swift
+++ b/VirgilCryptoFoundation/Hkdf.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Hmac.swift
+++ b/VirgilCryptoFoundation/Hmac.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Hmac.swift
+++ b/VirgilCryptoFoundation/Hmac.swift
@@ -104,7 +104,7 @@ import VSCFoundation
     @objc public func mac(key: Data, data: Data) -> Data {
         let macCount = self.digestLen()
         var mac = Data(count: macCount)
-        var macBuf = vsc_buffer_new()
+        let macBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(macBuf)
         }
@@ -143,7 +143,7 @@ import VSCFoundation
     @objc public func finish() -> Data {
         let macCount = self.digestLen()
         var mac = Data(count: macCount)
-        var macBuf = vsc_buffer_new()
+        let macBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(macBuf)
         }

--- a/VirgilCryptoFoundation/HybridKeyAlg.swift
+++ b/VirgilCryptoFoundation/HybridKeyAlg.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/HybridKeyAlg.swift
+++ b/VirgilCryptoFoundation/HybridKeyAlg.swift
@@ -216,7 +216,7 @@ import VSCFoundation
     @objc public func encrypt(publicKey: PublicKey, data: Data) throws -> Data {
         let outCount = self.encryptedLen(publicKey: publicKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -254,7 +254,7 @@ import VSCFoundation
     @objc public func decrypt(privateKey: PrivateKey, data: Data) throws -> Data {
         let outCount = self.decryptedLen(privateKey: privateKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -292,7 +292,7 @@ import VSCFoundation
     @objc public func signHash(privateKey: PrivateKey, hashId: AlgId, digest: Data) throws -> Data {
         let signatureCount = self.signatureLen(privateKey: privateKey)
         var signature = Data(count: signatureCount)
-        var signatureBuf = vsc_buffer_new()
+        let signatureBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(signatureBuf)
         }

--- a/VirgilCryptoFoundation/HybridKeyAlgInfo.swift
+++ b/VirgilCryptoFoundation/HybridKeyAlgInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/HybridPrivateKey.swift
+++ b/VirgilCryptoFoundation/HybridPrivateKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/HybridPublicKey.swift
+++ b/VirgilCryptoFoundation/HybridPublicKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Info.plist
+++ b/VirgilCryptoFoundation/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.15.2</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/VirgilCryptoFoundation/Kdf.swift
+++ b/VirgilCryptoFoundation/Kdf.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Kdf1.swift
+++ b/VirgilCryptoFoundation/Kdf1.swift
@@ -97,7 +97,7 @@ import VSCFoundation
     @objc public func derive(data: Data, keyLen: Int) -> Data {
         let keyCount = keyLen
         var key = Data(count: keyCount)
-        var keyBuf = vsc_buffer_new()
+        let keyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(keyBuf)
         }

--- a/VirgilCryptoFoundation/Kdf1.swift
+++ b/VirgilCryptoFoundation/Kdf1.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Kdf2.swift
+++ b/VirgilCryptoFoundation/Kdf2.swift
@@ -97,7 +97,7 @@ import VSCFoundation
     @objc public func derive(data: Data, keyLen: Int) -> Data {
         let keyCount = keyLen
         var key = Data(count: keyCount)
-        var keyBuf = vsc_buffer_new()
+        let keyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(keyBuf)
         }

--- a/VirgilCryptoFoundation/Kdf2.swift
+++ b/VirgilCryptoFoundation/Kdf2.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Kem.swift
+++ b/VirgilCryptoFoundation/Kem.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Key.swift
+++ b/VirgilCryptoFoundation/Key.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyAlg.swift
+++ b/VirgilCryptoFoundation/KeyAlg.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyAlgFactory.swift
+++ b/VirgilCryptoFoundation/KeyAlgFactory.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyAsn1Deserializer.swift
+++ b/VirgilCryptoFoundation/KeyAsn1Deserializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyAsn1Serializer.swift
+++ b/VirgilCryptoFoundation/KeyAsn1Serializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyAsn1Serializer.swift
+++ b/VirgilCryptoFoundation/KeyAsn1Serializer.swift
@@ -136,7 +136,7 @@ import VSCFoundation
     @objc public func serializePublicKey(publicKey: RawPublicKey) throws -> Data {
         let outCount = self.serializedPublicKeyLen(publicKey: publicKey)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -168,7 +168,7 @@ import VSCFoundation
     @objc public func serializePrivateKey(privateKey: RawPrivateKey) throws -> Data {
         let outCount = self.serializedPrivateKeyLen(privateKey: privateKey)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/KeyCipher.swift
+++ b/VirgilCryptoFoundation/KeyCipher.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyDeserializer.swift
+++ b/VirgilCryptoFoundation/KeyDeserializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyInfo.swift
+++ b/VirgilCryptoFoundation/KeyInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyMaterialRng.swift
+++ b/VirgilCryptoFoundation/KeyMaterialRng.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyMaterialRng.swift
+++ b/VirgilCryptoFoundation/KeyMaterialRng.swift
@@ -87,7 +87,7 @@ import VSCFoundation
     @objc public func random(dataLen: Int) throws -> Data {
         let dataCount = dataLen
         var data = Data(count: dataCount)
-        var dataBuf = vsc_buffer_new()
+        let dataBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(dataBuf)
         }

--- a/VirgilCryptoFoundation/KeyProvider.swift
+++ b/VirgilCryptoFoundation/KeyProvider.swift
@@ -202,7 +202,7 @@ import VSCFoundation
     @objc public func exportPublicKey(publicKey: PublicKey) throws -> Data {
         let outCount = self.exportedPublicKeyLen(publicKey: publicKey)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -234,7 +234,7 @@ import VSCFoundation
     @objc public func exportPrivateKey(privateKey: PrivateKey) throws -> Data {
         let outCount = self.exportedPrivateKeyLen(privateKey: privateKey)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/KeyProvider.swift
+++ b/VirgilCryptoFoundation/KeyProvider.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyRecipientInfo.swift
+++ b/VirgilCryptoFoundation/KeyRecipientInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeyRecipientInfoList.swift
+++ b/VirgilCryptoFoundation/KeyRecipientInfoList.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeySerializer.swift
+++ b/VirgilCryptoFoundation/KeySerializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/KeySigner.swift
+++ b/VirgilCryptoFoundation/KeySigner.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Mac.swift
+++ b/VirgilCryptoFoundation/Mac.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/MessageInfo.swift
+++ b/VirgilCryptoFoundation/MessageInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/MessageInfoCustomParams.swift
+++ b/VirgilCryptoFoundation/MessageInfoCustomParams.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/MessageInfoDerSerializer.swift
+++ b/VirgilCryptoFoundation/MessageInfoDerSerializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/MessageInfoDerSerializer.swift
+++ b/VirgilCryptoFoundation/MessageInfoDerSerializer.swift
@@ -95,7 +95,7 @@ import VSCFoundation
     @objc public func serialize(messageInfo: MessageInfo) -> Data {
         let outCount = self.serializedLen(messageInfo: messageInfo)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -150,7 +150,7 @@ import VSCFoundation
     @objc public func serializeFooter(messageInfoFooter: MessageInfoFooter) -> Data {
         let outCount = self.serializedFooterLen(messageInfoFooter: messageInfoFooter)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/MessageInfoEditor.swift
+++ b/VirgilCryptoFoundation/MessageInfoEditor.swift
@@ -146,7 +146,7 @@ import VSCFoundation
     @objc public func pack() -> Data {
         let messageInfoCount = self.packedLen()
         var messageInfo = Data(count: messageInfoCount)
-        var messageInfoBuf = vsc_buffer_new()
+        let messageInfoBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(messageInfoBuf)
         }

--- a/VirgilCryptoFoundation/MessageInfoEditor.swift
+++ b/VirgilCryptoFoundation/MessageInfoEditor.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/MessageInfoFooter.swift
+++ b/VirgilCryptoFoundation/MessageInfoFooter.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/MessageInfoFooterSerializer.swift
+++ b/VirgilCryptoFoundation/MessageInfoFooterSerializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/MessageInfoSerializer.swift
+++ b/VirgilCryptoFoundation/MessageInfoSerializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Oid.swift
+++ b/VirgilCryptoFoundation/Oid.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/OidId.swift
+++ b/VirgilCryptoFoundation/OidId.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Padding.swift
+++ b/VirgilCryptoFoundation/Padding.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/PaddingParams.swift
+++ b/VirgilCryptoFoundation/PaddingParams.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/PasswordRecipientInfo.swift
+++ b/VirgilCryptoFoundation/PasswordRecipientInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/PasswordRecipientInfoList.swift
+++ b/VirgilCryptoFoundation/PasswordRecipientInfoList.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/PbeAlgInfo.swift
+++ b/VirgilCryptoFoundation/PbeAlgInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Pem.swift
+++ b/VirgilCryptoFoundation/Pem.swift
@@ -52,7 +52,7 @@ import VSCFoundation
     @objc public static func wrap(title: String, data: Data) -> Data {
         let pemCount = Pem.wrappedLen(title: title, dataLen: data.count)
         var pem = Data(count: pemCount)
-        var pemBuf = vsc_buffer_new()
+        let pemBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(pemBuf)
         }
@@ -80,7 +80,7 @@ import VSCFoundation
     @objc public static func unwrap(pem: Data) throws -> Data {
         let dataCount = Pem.unwrappedLen(pemLen: pem.count)
         var data = Data(count: dataCount)
-        var dataBuf = vsc_buffer_new()
+        let dataBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(dataBuf)
         }

--- a/VirgilCryptoFoundation/Pem.swift
+++ b/VirgilCryptoFoundation/Pem.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Pkcs5Pbes2.swift
+++ b/VirgilCryptoFoundation/Pkcs5Pbes2.swift
@@ -110,7 +110,7 @@ import VSCFoundation
     @objc public func encrypt(data: Data) throws -> Data {
         let outCount = self.encryptedLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -147,7 +147,7 @@ import VSCFoundation
     @objc public func decrypt(data: Data) throws -> Data {
         let outCount = self.decryptedLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/Pkcs5Pbes2.swift
+++ b/VirgilCryptoFoundation/Pkcs5Pbes2.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Pkcs5Pbkdf2.swift
+++ b/VirgilCryptoFoundation/Pkcs5Pbkdf2.swift
@@ -102,7 +102,7 @@ import VSCFoundation
     @objc public func derive(data: Data, keyLen: Int) -> Data {
         let keyCount = keyLen
         var key = Data(count: keyCount)
-        var keyBuf = vsc_buffer_new()
+        let keyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(keyBuf)
         }

--- a/VirgilCryptoFoundation/Pkcs5Pbkdf2.swift
+++ b/VirgilCryptoFoundation/Pkcs5Pbkdf2.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Pkcs8Serializer.swift
+++ b/VirgilCryptoFoundation/Pkcs8Serializer.swift
@@ -134,7 +134,7 @@ import VSCFoundation
     @objc public func serializePublicKey(publicKey: RawPublicKey) throws -> Data {
         let outCount = self.serializedPublicKeyLen(publicKey: publicKey)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -166,7 +166,7 @@ import VSCFoundation
     @objc public func serializePrivateKey(privateKey: RawPrivateKey) throws -> Data {
         let outCount = self.serializedPrivateKeyLen(privateKey: privateKey)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/Pkcs8Serializer.swift
+++ b/VirgilCryptoFoundation/Pkcs8Serializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/PrivateKey.swift
+++ b/VirgilCryptoFoundation/PrivateKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/PublicKey.swift
+++ b/VirgilCryptoFoundation/PublicKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Random.swift
+++ b/VirgilCryptoFoundation/Random.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/RandomPadding.swift
+++ b/VirgilCryptoFoundation/RandomPadding.swift
@@ -140,7 +140,7 @@ import VSCFoundation
     @objc public func finishDataProcessing() throws -> Data {
         let outCount = self.len()
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -167,7 +167,7 @@ import VSCFoundation
     @objc public func processPaddedData(data: Data) -> Data {
         let outCount = data.count
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -196,7 +196,7 @@ import VSCFoundation
     @objc public func finishPaddedDataProcessing() throws -> Data {
         let outCount = self.finishPaddedDataProcessingOutLen()
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/RandomPadding.swift
+++ b/VirgilCryptoFoundation/RandomPadding.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/RawPrivateKey.swift
+++ b/VirgilCryptoFoundation/RawPrivateKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/RawPublicKey.swift
+++ b/VirgilCryptoFoundation/RawPublicKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/RecipientCipher.swift
+++ b/VirgilCryptoFoundation/RecipientCipher.swift
@@ -181,7 +181,7 @@ import VSCFoundation
     @objc public func packMessageInfo() -> Data {
         let messageInfoCount = self.messageInfoLen()
         var messageInfo = Data(count: messageInfoCount)
-        var messageInfoBuf = vsc_buffer_new()
+        let messageInfoBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(messageInfoBuf)
         }
@@ -208,7 +208,7 @@ import VSCFoundation
     @objc public func processEncryption(data: Data) throws -> Data {
         let outCount = self.encryptionOutLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -231,7 +231,7 @@ import VSCFoundation
     @objc public func finishEncryption() throws -> Data {
         let outCount = self.encryptionOutLen(dataLen: 0)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -291,7 +291,7 @@ import VSCFoundation
     @objc public func processDecryption(data: Data) throws -> Data {
         let outCount = self.decryptionOutLen(dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -314,7 +314,7 @@ import VSCFoundation
     @objc public func finishDecryption() throws -> Data {
         let outCount = self.decryptionOutLen(dataLen: 0)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -378,7 +378,7 @@ import VSCFoundation
     @objc public func packMessageInfoFooter() throws -> Data {
         let outCount = self.messageInfoFooterLen()
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/RecipientCipher.swift
+++ b/VirgilCryptoFoundation/RecipientCipher.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Round5.swift
+++ b/VirgilCryptoFoundation/Round5.swift
@@ -206,14 +206,14 @@ import VSCFoundation
     @objc public func kemEncapsulate(publicKey: PublicKey) throws -> KemKemEncapsulateResult {
         let sharedKeyCount = self.kemSharedKeyLen(key: publicKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }
 
         let encapsulatedKeyCount = self.kemEncapsulatedKeyLen(publicKey: publicKey)
         var encapsulatedKey = Data(count: encapsulatedKeyCount)
-        var encapsulatedKeyBuf = vsc_buffer_new()
+        let encapsulatedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(encapsulatedKeyBuf)
         }
@@ -239,7 +239,7 @@ import VSCFoundation
     @objc public func kemDecapsulate(encapsulatedKey: Data, privateKey: PrivateKey) throws -> Data {
         let sharedKeyCount = self.kemSharedKeyLen(key: privateKey)
         var sharedKey = Data(count: sharedKeyCount)
-        var sharedKeyBuf = vsc_buffer_new()
+        let sharedKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(sharedKeyBuf)
         }

--- a/VirgilCryptoFoundation/Round5.swift
+++ b/VirgilCryptoFoundation/Round5.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Rsa.swift
+++ b/VirgilCryptoFoundation/Rsa.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Rsa.swift
+++ b/VirgilCryptoFoundation/Rsa.swift
@@ -205,7 +205,7 @@ import VSCFoundation
     @objc public func encrypt(publicKey: PublicKey, data: Data) throws -> Data {
         let outCount = self.encryptedLen(publicKey: publicKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -243,7 +243,7 @@ import VSCFoundation
     @objc public func decrypt(privateKey: PrivateKey, data: Data) throws -> Data {
         let outCount = self.decryptedLen(privateKey: privateKey, dataLen: data.count)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -281,7 +281,7 @@ import VSCFoundation
     @objc public func signHash(privateKey: PrivateKey, hashId: AlgId, digest: Data) throws -> Data {
         let signatureCount = self.signatureLen(privateKey: privateKey)
         var signature = Data(count: signatureCount)
-        var signatureBuf = vsc_buffer_new()
+        let signatureBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(signatureBuf)
         }

--- a/VirgilCryptoFoundation/RsaPrivateKey.swift
+++ b/VirgilCryptoFoundation/RsaPrivateKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/RsaPublicKey.swift
+++ b/VirgilCryptoFoundation/RsaPublicKey.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/SaltedKdf.swift
+++ b/VirgilCryptoFoundation/SaltedKdf.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/SaltedKdfAlgInfo.swift
+++ b/VirgilCryptoFoundation/SaltedKdfAlgInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Sec1Serializer.swift
+++ b/VirgilCryptoFoundation/Sec1Serializer.swift
@@ -135,7 +135,7 @@ import VSCFoundation
     @objc public func serializePublicKey(publicKey: RawPublicKey) throws -> Data {
         let outCount = self.serializedPublicKeyLen(publicKey: publicKey)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }
@@ -167,7 +167,7 @@ import VSCFoundation
     @objc public func serializePrivateKey(privateKey: RawPrivateKey) throws -> Data {
         let outCount = self.serializedPrivateKeyLen(privateKey: privateKey)
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/Sec1Serializer.swift
+++ b/VirgilCryptoFoundation/Sec1Serializer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/SeedEntropySource.swift
+++ b/VirgilCryptoFoundation/SeedEntropySource.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/SeedEntropySource.swift
+++ b/VirgilCryptoFoundation/SeedEntropySource.swift
@@ -86,7 +86,7 @@ import VSCFoundation
     @objc public func gather(len: Int) throws -> Data {
         let outCount = len
         var out = Data(count: outCount)
-        var outBuf = vsc_buffer_new()
+        let outBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outBuf)
         }

--- a/VirgilCryptoFoundation/Sha224.swift
+++ b/VirgilCryptoFoundation/Sha224.swift
@@ -98,7 +98,7 @@ import VSCFoundation
     @objc public func hash(data: Data) -> Data {
         let digestCount = self.digestLen
         var digest = Data(count: digestCount)
-        var digestBuf = vsc_buffer_new()
+        let digestBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(digestBuf)
         }
@@ -132,7 +132,7 @@ import VSCFoundation
     @objc public func finish() -> Data {
         let digestCount = self.digestLen
         var digest = Data(count: digestCount)
-        var digestBuf = vsc_buffer_new()
+        let digestBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(digestBuf)
         }

--- a/VirgilCryptoFoundation/Sha224.swift
+++ b/VirgilCryptoFoundation/Sha224.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Sha256.swift
+++ b/VirgilCryptoFoundation/Sha256.swift
@@ -98,7 +98,7 @@ import VSCFoundation
     @objc public func hash(data: Data) -> Data {
         let digestCount = self.digestLen
         var digest = Data(count: digestCount)
-        var digestBuf = vsc_buffer_new()
+        let digestBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(digestBuf)
         }
@@ -132,7 +132,7 @@ import VSCFoundation
     @objc public func finish() -> Data {
         let digestCount = self.digestLen
         var digest = Data(count: digestCount)
-        var digestBuf = vsc_buffer_new()
+        let digestBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(digestBuf)
         }

--- a/VirgilCryptoFoundation/Sha256.swift
+++ b/VirgilCryptoFoundation/Sha256.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Sha384.swift
+++ b/VirgilCryptoFoundation/Sha384.swift
@@ -98,7 +98,7 @@ import VSCFoundation
     @objc public func hash(data: Data) -> Data {
         let digestCount = self.digestLen
         var digest = Data(count: digestCount)
-        var digestBuf = vsc_buffer_new()
+        let digestBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(digestBuf)
         }
@@ -132,7 +132,7 @@ import VSCFoundation
     @objc public func finish() -> Data {
         let digestCount = self.digestLen
         var digest = Data(count: digestCount)
-        var digestBuf = vsc_buffer_new()
+        let digestBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(digestBuf)
         }

--- a/VirgilCryptoFoundation/Sha384.swift
+++ b/VirgilCryptoFoundation/Sha384.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Sha512.swift
+++ b/VirgilCryptoFoundation/Sha512.swift
@@ -98,7 +98,7 @@ import VSCFoundation
     @objc public func hash(data: Data) -> Data {
         let digestCount = self.digestLen
         var digest = Data(count: digestCount)
-        var digestBuf = vsc_buffer_new()
+        let digestBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(digestBuf)
         }
@@ -132,7 +132,7 @@ import VSCFoundation
     @objc public func finish() -> Data {
         let digestCount = self.digestLen
         var digest = Data(count: digestCount)
-        var digestBuf = vsc_buffer_new()
+        let digestBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(digestBuf)
         }

--- a/VirgilCryptoFoundation/Sha512.swift
+++ b/VirgilCryptoFoundation/Sha512.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/SignedDataInfo.swift
+++ b/VirgilCryptoFoundation/SignedDataInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Signer.swift
+++ b/VirgilCryptoFoundation/Signer.swift
@@ -101,7 +101,7 @@ import VSCFoundation
     @objc public func sign(privateKey: PrivateKey) throws -> Data {
         let signatureCount = self.signatureLen(privateKey: privateKey)
         var signature = Data(count: signatureCount)
-        var signatureBuf = vsc_buffer_new()
+        let signatureBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(signatureBuf)
         }

--- a/VirgilCryptoFoundation/Signer.swift
+++ b/VirgilCryptoFoundation/Signer.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/SignerInfo.swift
+++ b/VirgilCryptoFoundation/SignerInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/SignerInfoList.swift
+++ b/VirgilCryptoFoundation/SignerInfoList.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/SimpleAlgInfo.swift
+++ b/VirgilCryptoFoundation/SimpleAlgInfo.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/Verifier.swift
+++ b/VirgilCryptoFoundation/Verifier.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoFoundation/VirgilCryptoFoundation.h
+++ b/VirgilCryptoFoundation/VirgilCryptoFoundation.h
@@ -1,6 +1,6 @@
 //  @license
 // --------------------------------------------------------------------------
-//  Copyright (C) 2015-2019 Virgil Security, Inc.
+//  Copyright (C) 2015-2021 Virgil Security, Inc.
 //
 //  All rights reserved.
 //

--- a/VirgilCryptoFoundationTests/VirgilCryptoFoundationTests.swift
+++ b/VirgilCryptoFoundationTests/VirgilCryptoFoundationTests.swift
@@ -1,6 +1,6 @@
 //  @license
 // --------------------------------------------------------------------------
-//  Copyright (C) 2015-2019 Virgil Security, Inc.
+//  Copyright (C) 2015-2021 Virgil Security, Inc.
 //
 //  All rights reserved.
 //

--- a/VirgilCryptoPythia.podspec
+++ b/VirgilCryptoPythia.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "VirgilCryptoPythia"
-  s.version                     = "0.16.0-rc1"
+  s.version                     = "0.16.0"
   s.swift_version               = "5.0"
   s.license                     = { :type => "BSD", :file => "LICENSE" }
   s.summary                     = "Contains swift classes working with Pythia crypto."
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target   = "2.0"
   s.public_header_files         = "VirgilCryptoPythia/VirgilCryptoPythia.h"
   s.source_files                = "VirgilCryptoPythia/**/*.{h,mm,swift}"
-  s.dependency 'VirgilCryptoFoundation', '= 0.16.0-rc1'
-  s.dependency 'VSCCrypto/Common', '= 0.16.0-rc1'
-  s.dependency 'VSCCrypto/Foundation', '= 0.16.0-rc1'
-  s.dependency 'VSCCrypto/Pythia', '= 0.16.0-rc1'
+  s.dependency 'VirgilCryptoFoundation', '= 0.16.0'
+  s.dependency 'VSCCrypto/Common', '= 0.16.0'
+  s.dependency 'VSCCrypto/Foundation', '= 0.16.0'
+  s.dependency 'VSCCrypto/Pythia', '= 0.16.0'
 end

--- a/VirgilCryptoPythia.podspec
+++ b/VirgilCryptoPythia.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "VirgilCryptoPythia"
-  s.version                     = "0.15.2"
+  s.version                     = "0.16.0"
   s.swift_version               = "5.0"
   s.license                     = { :type => "BSD", :file => "LICENSE" }
   s.summary                     = "Contains swift classes working with Pythia crypto."
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target   = "2.0"
   s.public_header_files         = "VirgilCryptoPythia/VirgilCryptoPythia.h"
   s.source_files                = "VirgilCryptoPythia/**/*.{h,mm,swift}"
-  s.dependency 'VirgilCryptoFoundation', '= 0.15.2'
-  s.dependency 'VSCCrypto/Common', '= 0.15.2'
-  s.dependency 'VSCCrypto/Foundation', '= 0.15.2'
-  s.dependency 'VSCCrypto/Pythia', '= 0.15.2'
+  s.dependency 'VirgilCryptoFoundation', '= 0.16.0'
+  s.dependency 'VSCCrypto/Common', '= 0.16.0'
+  s.dependency 'VSCCrypto/Foundation', '= 0.16.0'
+  s.dependency 'VSCCrypto/Pythia', '= 0.16.0'
 end

--- a/VirgilCryptoPythia.podspec
+++ b/VirgilCryptoPythia.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "VirgilCryptoPythia"
-  s.version                     = "0.16.0"
+  s.version                     = "0.16.0-rc1"
   s.swift_version               = "5.0"
   s.license                     = { :type => "BSD", :file => "LICENSE" }
   s.summary                     = "Contains swift classes working with Pythia crypto."
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target   = "2.0"
   s.public_header_files         = "VirgilCryptoPythia/VirgilCryptoPythia.h"
   s.source_files                = "VirgilCryptoPythia/**/*.{h,mm,swift}"
-  s.dependency 'VirgilCryptoFoundation', '= 0.16.0'
-  s.dependency 'VSCCrypto/Common', '= 0.16.0'
-  s.dependency 'VSCCrypto/Foundation', '= 0.16.0'
-  s.dependency 'VSCCrypto/Pythia', '= 0.16.0'
+  s.dependency 'VirgilCryptoFoundation', '= 0.16.0-rc1'
+  s.dependency 'VSCCrypto/Common', '= 0.16.0-rc1'
+  s.dependency 'VSCCrypto/Foundation', '= 0.16.0-rc1'
+  s.dependency 'VSCCrypto/Pythia', '= 0.16.0-rc1'
 end

--- a/VirgilCryptoPythia/CContext.swift
+++ b/VirgilCryptoPythia/CContext.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoPythia/Info.plist
+++ b/VirgilCryptoPythia/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.15.2</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/VirgilCryptoPythia/Pythia.swift
+++ b/VirgilCryptoPythia/Pythia.swift
@@ -121,14 +121,14 @@ import VSCPythia
     @objc public static func blind(password: Data) throws -> PythiaBlindResult {
         let blindedPasswordCount = Pythia.blindedPasswordBufLen()
         var blindedPassword = Data(count: blindedPasswordCount)
-        var blindedPasswordBuf = vsc_buffer_new()
+        let blindedPasswordBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(blindedPasswordBuf)
         }
 
         let blindingSecretCount = Pythia.blindingSecretBufLen()
         var blindingSecret = Data(count: blindingSecretCount)
-        var blindingSecretBuf = vsc_buffer_new()
+        let blindingSecretBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(blindingSecretBuf)
         }
@@ -156,7 +156,7 @@ import VSCPythia
     @objc public static func deblind(transformedPassword: Data, blindingSecret: Data) throws -> Data {
         let deblindedPasswordCount = Pythia.deblindedPasswordBufLen()
         var deblindedPassword = Data(count: deblindedPasswordCount)
-        var deblindedPasswordBuf = vsc_buffer_new()
+        let deblindedPasswordBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(deblindedPasswordBuf)
         }
@@ -181,14 +181,14 @@ import VSCPythia
     @objc public static func computeTransformationKeyPair(transformationKeyId: Data, pythiaSecret: Data, pythiaScopeSecret: Data) throws -> PythiaComputeTransformationKeyPairResult {
         let transformationPrivateKeyCount = Pythia.transformationPrivateKeyBufLen()
         var transformationPrivateKey = Data(count: transformationPrivateKeyCount)
-        var transformationPrivateKeyBuf = vsc_buffer_new()
+        let transformationPrivateKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(transformationPrivateKeyBuf)
         }
 
         let transformationPublicKeyCount = Pythia.transformationPublicKeyBufLen()
         var transformationPublicKey = Data(count: transformationPublicKeyCount)
-        var transformationPublicKeyBuf = vsc_buffer_new()
+        let transformationPublicKeyBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(transformationPublicKeyBuf)
         }
@@ -220,14 +220,14 @@ import VSCPythia
     @objc public static func transform(blindedPassword: Data, tweak: Data, transformationPrivateKey: Data) throws -> PythiaTransformResult {
         let transformedPasswordCount = Pythia.transformedPasswordBufLen()
         var transformedPassword = Data(count: transformedPasswordCount)
-        var transformedPasswordBuf = vsc_buffer_new()
+        let transformedPasswordBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(transformedPasswordBuf)
         }
 
         let transformedTweakCount = Pythia.transformedTweakBufLen()
         var transformedTweak = Data(count: transformedTweakCount)
-        var transformedTweakBuf = vsc_buffer_new()
+        let transformedTweakBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(transformedTweakBuf)
         }
@@ -259,14 +259,14 @@ import VSCPythia
     @objc public static func prove(transformedPassword: Data, blindedPassword: Data, transformedTweak: Data, transformationPrivateKey: Data, transformationPublicKey: Data) throws -> PythiaProveResult {
         let proofValueCCount = Pythia.proofValueBufLen()
         var proofValueC = Data(count: proofValueCCount)
-        var proofValueCBuf = vsc_buffer_new()
+        let proofValueCBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(proofValueCBuf)
         }
 
         let proofValueUCount = Pythia.proofValueBufLen()
         var proofValueU = Data(count: proofValueUCount)
-        var proofValueUBuf = vsc_buffer_new()
+        let proofValueUBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(proofValueUBuf)
         }
@@ -337,7 +337,7 @@ import VSCPythia
     @objc public static func getPasswordUpdateToken(previousTransformationPrivateKey: Data, newTransformationPrivateKey: Data) throws -> Data {
         let passwordUpdateTokenCount = Pythia.passwordUpdateTokenBufLen()
         var passwordUpdateToken = Data(count: passwordUpdateTokenCount)
-        var passwordUpdateTokenBuf = vsc_buffer_new()
+        let passwordUpdateTokenBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(passwordUpdateTokenBuf)
         }
@@ -363,7 +363,7 @@ import VSCPythia
     @objc public static func updateDeblindedWithToken(deblindedPassword: Data, passwordUpdateToken: Data) throws -> Data {
         let updatedDeblindedPasswordCount = Pythia.deblindedPasswordBufLen()
         var updatedDeblindedPassword = Data(count: updatedDeblindedPasswordCount)
-        var updatedDeblindedPasswordBuf = vsc_buffer_new()
+        let updatedDeblindedPasswordBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(updatedDeblindedPasswordBuf)
         }

--- a/VirgilCryptoPythia/Pythia.swift
+++ b/VirgilCryptoPythia/Pythia.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoPythia/PythiaError.swift
+++ b/VirgilCryptoPythia/PythiaError.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoPythia/PythiaImplementation.swift
+++ b/VirgilCryptoPythia/PythiaImplementation.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoPythia/VirgilCryptoPythia.h
+++ b/VirgilCryptoPythia/VirgilCryptoPythia.h
@@ -1,6 +1,6 @@
 //  @license
 // --------------------------------------------------------------------------
-//  Copyright (C) 2015-2019 Virgil Security, Inc.
+//  Copyright (C) 2015-2021 Virgil Security, Inc.
 //
 //  All rights reserved.
 //

--- a/VirgilCryptoPythiaTests/VirgilCryptoPythiaTests.swift
+++ b/VirgilCryptoPythiaTests/VirgilCryptoPythiaTests.swift
@@ -1,6 +1,6 @@
 //  @license
 // --------------------------------------------------------------------------
-//  Copyright (C) 2015-2019 Virgil Security, Inc.
+//  Copyright (C) 2015-2021 Virgil Security, Inc.
 //
 //  All rights reserved.
 //

--- a/VirgilCryptoRatchet.podspec
+++ b/VirgilCryptoRatchet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "VirgilCryptoRatchet"
-  s.version                     = "0.16.0-rc1"
+  s.version                     = "0.16.0"
   s.swift_version               = "5.0"
   s.license                     = { :type => "BSD", :file => "LICENSE" }
   s.summary                     = "Contains swift for double ratchet crypto operations."
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.public_header_files         = "VirgilCryptoRatchet/VirgilCryptoRatchet.h"
   s.source_files                = "VirgilCryptoRatchet/**/*.{h,mm,swift}"
   s.dependency 'VirgilCryptoFoundation', '= 0.16.0-rc1'
-  s.dependency 'VSCCrypto/Common', '= 0.16.0-rc1'
-  s.dependency 'VSCCrypto/Foundation', '= 0.16.0-rc1'
-  s.dependency 'VSCCrypto/Ratchet', '= 0.16.0-rc1'
+  s.dependency 'VSCCrypto/Common', '= 0.16.0'
+  s.dependency 'VSCCrypto/Foundation', '= 0.16.0'
+  s.dependency 'VSCCrypto/Ratchet', '= 0.16.0'
 end

--- a/VirgilCryptoRatchet.podspec
+++ b/VirgilCryptoRatchet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "VirgilCryptoRatchet"
-  s.version                     = "0.16.0"
+  s.version                     = "0.16.0-rc1"
   s.swift_version               = "5.0"
   s.license                     = { :type => "BSD", :file => "LICENSE" }
   s.summary                     = "Contains swift for double ratchet crypto operations."
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target   = "2.0"
   s.public_header_files         = "VirgilCryptoRatchet/VirgilCryptoRatchet.h"
   s.source_files                = "VirgilCryptoRatchet/**/*.{h,mm,swift}"
-  s.dependency 'VirgilCryptoFoundation', '= 0.16.0'
-  s.dependency 'VSCCrypto/Common', '= 0.16.0'
-  s.dependency 'VSCCrypto/Foundation', '= 0.16.0'
-  s.dependency 'VSCCrypto/Ratchet', '= 0.16.0'
+  s.dependency 'VirgilCryptoFoundation', '= 0.16.0-rc1'
+  s.dependency 'VSCCrypto/Common', '= 0.16.0-rc1'
+  s.dependency 'VSCCrypto/Foundation', '= 0.16.0-rc1'
+  s.dependency 'VSCCrypto/Ratchet', '= 0.16.0-rc1'
 end

--- a/VirgilCryptoRatchet.podspec
+++ b/VirgilCryptoRatchet.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target   = "2.0"
   s.public_header_files         = "VirgilCryptoRatchet/VirgilCryptoRatchet.h"
   s.source_files                = "VirgilCryptoRatchet/**/*.{h,mm,swift}"
-  s.dependency 'VirgilCryptoFoundation', '= 0.16.0-rc1'
+  s.dependency 'VirgilCryptoFoundation', '= 0.16.0'
   s.dependency 'VSCCrypto/Common', '= 0.16.0'
   s.dependency 'VSCCrypto/Foundation', '= 0.16.0'
   s.dependency 'VSCCrypto/Ratchet', '= 0.16.0'

--- a/VirgilCryptoRatchet.podspec
+++ b/VirgilCryptoRatchet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "VirgilCryptoRatchet"
-  s.version                     = "0.15.2"
+  s.version                     = "0.16.0"
   s.swift_version               = "5.0"
   s.license                     = { :type => "BSD", :file => "LICENSE" }
   s.summary                     = "Contains swift for double ratchet crypto operations."
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target   = "2.0"
   s.public_header_files         = "VirgilCryptoRatchet/VirgilCryptoRatchet.h"
   s.source_files                = "VirgilCryptoRatchet/**/*.{h,mm,swift}"
-  s.dependency 'VirgilCryptoFoundation', '= 0.15.2'
-  s.dependency 'VSCCrypto/Common', '= 0.15.2'
-  s.dependency 'VSCCrypto/Foundation', '= 0.15.2'
-  s.dependency 'VSCCrypto/Ratchet', '= 0.15.2'
+  s.dependency 'VirgilCryptoFoundation', '= 0.16.0'
+  s.dependency 'VSCCrypto/Common', '= 0.16.0'
+  s.dependency 'VSCCrypto/Foundation', '= 0.16.0'
+  s.dependency 'VSCCrypto/Ratchet', '= 0.16.0'
 end

--- a/VirgilCryptoRatchet/CContext.swift
+++ b/VirgilCryptoRatchet/CContext.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoRatchet/GroupMsgType.swift
+++ b/VirgilCryptoRatchet/GroupMsgType.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoRatchet/Info.plist
+++ b/VirgilCryptoRatchet/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.15.2</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/VirgilCryptoRatchet/MsgType.swift
+++ b/VirgilCryptoRatchet/MsgType.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoRatchet/RatchetCommon.swift
+++ b/VirgilCryptoRatchet/RatchetCommon.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoRatchet/RatchetError.swift
+++ b/VirgilCryptoRatchet/RatchetError.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoRatchet/RatchetImplementation.swift
+++ b/VirgilCryptoRatchet/RatchetImplementation.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoRatchet/RatchetMessage.swift
+++ b/VirgilCryptoRatchet/RatchetMessage.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoRatchet/RatchetMessage.swift
+++ b/VirgilCryptoRatchet/RatchetMessage.swift
@@ -121,7 +121,7 @@ import VirgilCryptoFoundation
     @objc public func serialize() -> Data {
         let outputCount = self.serializeLen()
         var output = Data(count: outputCount)
-        var outputBuf = vsc_buffer_new()
+        let outputBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(outputBuf)
         }

--- a/VirgilCryptoRatchet/RatchetSession.swift
+++ b/VirgilCryptoRatchet/RatchetSession.swift
@@ -1,4 +1,4 @@
-/// Copyright (C) 2015-2020 Virgil Security, Inc.
+/// Copyright (C) 2015-2021 Virgil Security, Inc.
 ///
 /// All rights reserved.
 ///

--- a/VirgilCryptoRatchet/RatchetSession.swift
+++ b/VirgilCryptoRatchet/RatchetSession.swift
@@ -180,7 +180,7 @@ import VirgilCryptoFoundation
     @objc public func decrypt(message: RatchetMessage) throws -> Data {
         let plainTextCount = self.decryptLen(message: message)
         var plainText = Data(count: plainTextCount)
-        var plainTextBuf = vsc_buffer_new()
+        let plainTextBuf = vsc_buffer_new()
         defer {
             vsc_buffer_delete(plainTextBuf)
         }

--- a/VirgilCryptoRatchet/VirgilCryptoRatchet.h
+++ b/VirgilCryptoRatchet/VirgilCryptoRatchet.h
@@ -1,6 +1,6 @@
 //  @license
 // --------------------------------------------------------------------------
-//  Copyright (C) 2015-2019 Virgil Security, Inc.
+//  Copyright (C) 2015-2021 Virgil Security, Inc.
 //
 //  All rights reserved.
 //

--- a/VirgilCryptoRatchetTests/VirgilCryptoRatchetTests.swift
+++ b/VirgilCryptoRatchetTests/VirgilCryptoRatchetTests.swift
@@ -1,6 +1,6 @@
 //  @license
 // --------------------------------------------------------------------------
-//  Copyright (C) 2015-2019 Virgil Security, Inc.
+//  Copyright (C) 2015-2021 Virgil Security, Inc.
 //
 //  All rights reserved.
 //

--- a/VirgilCryptoWrapper.xcodeproj/project.pbxproj
+++ b/VirgilCryptoWrapper.xcodeproj/project.pbxproj
@@ -1175,6 +1175,7 @@
 		970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VSCCommon.xcframework; path = Carthage/Build/VSCCommon.xcframework; sourceTree = "<group>"; };
 		970F4D95269DE64F002C8008 /* VSCPythia.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VSCPythia.xcframework; path = Carthage/Build/VSCPythia.xcframework; sourceTree = "<group>"; };
 		970F4DAB269DEA44002C8008 /* VSCRatchet.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VSCRatchet.xcframework; path = Carthage/Build/VSCRatchet.xcframework; sourceTree = "<group>"; };
+		97BBF840269E3017005C4901 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		9CAAC5006EFE70CDC79914851F6274F6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9E2CD4D12B41E25AACF6794F252A7B0E /* VSCPythia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = VSCPythia.framework; sourceTree = "<group>"; };
 		9EE38118ECBC048D102B40D29B44D277 /* VirgilCryptoRatchet-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "VirgilCryptoRatchet-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1698,6 +1699,7 @@
 				84A83205B0B91AB9992D3817B2978E7D /* VirgilCryptoPythiaTests */,
 				0A4F0F2B38B054B535552CA5A11E42E9 /* VirgilCryptoRatchet */,
 				AC0756634D85AC0C9B98B8202952BBEC /* VirgilCryptoRatchetTests */,
+				97BBF840269E3017005C4901 /* Config.xcconfig */,
 				71F6F543F531F81F040978F95429EF83 /* Frameworks */,
 				1F33D330B95E549A364389C16A6BAB4C /* Products */,
 			);
@@ -3210,7 +3212,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoPythia;
 				PRODUCT_NAME = VirgilCryptoPythia;
 				SDKROOT = macosx;
@@ -3265,7 +3266,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoPythia;
 				PRODUCT_NAME = VirgilCryptoPythia;
 				SDKROOT = macosx;
@@ -3292,7 +3292,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoPythia;
 				PRODUCT_NAME = VirgilCryptoPythia;
 				SDKROOT = iphoneos;
@@ -3320,7 +3319,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoRatchet;
 				PRODUCT_NAME = VirgilCryptoRatchet;
 				SDKROOT = iphoneos;
@@ -3344,7 +3342,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoRatchet;
 				PRODUCT_NAME = VirgilCryptoRatchet;
 				SDKROOT = watchos;
@@ -3393,7 +3390,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoFoundation;
 				PRODUCT_NAME = VirgilCryptoFoundation;
 				SDKROOT = appletvos;
@@ -3412,6 +3408,7 @@
 		};
 		2EA0FFFAB24C6B8647EC6800BB28CEE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 97BBF840269E3017005C4901 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -3481,7 +3478,6 @@
 				);
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoFoundation;
 				PRODUCT_NAME = VirgilCryptoFoundation;
 				SDKROOT = watchos;
@@ -3510,7 +3506,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoFoundation;
 				PRODUCT_NAME = VirgilCryptoFoundation;
 				SDKROOT = macosx;
@@ -3538,7 +3533,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoRatchet;
 				PRODUCT_NAME = VirgilCryptoRatchet;
 				SDKROOT = macosx;
@@ -3642,7 +3636,6 @@
 				);
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoFoundation;
 				PRODUCT_NAME = VirgilCryptoFoundation;
 				SDKROOT = watchos;
@@ -3692,7 +3685,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoRatchet;
 				PRODUCT_NAME = VirgilCryptoRatchet;
 				SDKROOT = macosx;
@@ -3719,7 +3711,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoRatchet;
 				PRODUCT_NAME = VirgilCryptoRatchet;
 				SDKROOT = appletvos;
@@ -3743,7 +3734,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoPythia;
 				PRODUCT_NAME = VirgilCryptoPythia;
 				SDKROOT = watchos;
@@ -3827,7 +3817,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoFoundation;
 				PRODUCT_NAME = VirgilCryptoFoundation;
 				SDKROOT = macosx;
@@ -3854,7 +3843,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoRatchet;
 				PRODUCT_NAME = VirgilCryptoRatchet;
 				SDKROOT = appletvos;
@@ -3882,7 +3870,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoRatchet;
 				PRODUCT_NAME = VirgilCryptoRatchet;
 				SDKROOT = iphoneos;
@@ -3934,7 +3921,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoFoundation;
 				PRODUCT_NAME = VirgilCryptoFoundation;
 				SDKROOT = iphoneos;
@@ -4019,7 +4005,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoPythia;
 				PRODUCT_NAME = VirgilCryptoPythia;
 				SDKROOT = appletvos;
@@ -4043,7 +4028,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoRatchet;
 				PRODUCT_NAME = VirgilCryptoRatchet;
 				SDKROOT = watchos;
@@ -4074,7 +4058,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoFoundation;
 				PRODUCT_NAME = VirgilCryptoFoundation;
 				SDKROOT = appletvos;
@@ -4102,7 +4085,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoPythia;
 				PRODUCT_NAME = VirgilCryptoPythia;
 				SDKROOT = appletvos;
@@ -4184,7 +4166,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoFoundation;
 				PRODUCT_NAME = VirgilCryptoFoundation;
 				SDKROOT = iphoneos;
@@ -4247,7 +4228,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoPythia;
 				PRODUCT_NAME = VirgilCryptoPythia;
 				SDKROOT = watchos;
@@ -4294,7 +4274,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoPythia;
 				PRODUCT_NAME = VirgilCryptoPythia;
 				SDKROOT = iphoneos;
@@ -4313,6 +4292,7 @@
 		};
 		F9CFC5B743020948B91D71B3ADF4B7C3 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 97BBF840269E3017005C4901 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/VirgilCryptoWrapper.xcodeproj/project.pbxproj
+++ b/VirgilCryptoWrapper.xcodeproj/project.pbxproj
@@ -3233,10 +3233,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythiaTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3372,6 +3369,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_NAME = "VirgilCryptoRatchet-Tests";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
@@ -3555,16 +3553,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythiaTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_NAME = "VirgilCryptoPythia-Tests";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
@@ -3575,10 +3571,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythiaTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3603,6 +3596,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "";
 				PRODUCT_NAME = "VirgilCryptoFoundation-Tests";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
@@ -3659,16 +3653,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythiaTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_NAME = "VirgilCryptoPythia-Tests";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
@@ -3764,6 +3756,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "";
 				PRODUCT_NAME = "VirgilCryptoFoundation-Tests";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -3801,6 +3794,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_NAME = "VirgilCryptoFoundation-Tests";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
@@ -3900,6 +3894,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_NAME = "VirgilCryptoFoundation-Tests";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
@@ -3961,16 +3956,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythiaTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = "VirgilCryptoPythia-Tests";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -3990,6 +3983,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_NAME = "VirgilCryptoRatchet-Tests";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
@@ -4188,10 +4182,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythiaTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/VirgilCryptoWrapper.xcodeproj/project.pbxproj
+++ b/VirgilCryptoWrapper.xcodeproj/project.pbxproj
@@ -3213,7 +3213,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3264,7 +3267,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3290,7 +3296,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3317,7 +3326,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3344,7 +3356,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoRatchet;
@@ -3388,7 +3403,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+					"$(PROJECT_DIR)/Carthage/Build/",
 				);
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3480,7 +3495,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+					"$(PROJECT_DIR)/Carthage/Build/",
 				);
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3505,7 +3520,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3532,7 +3550,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3634,7 +3655,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+					"$(PROJECT_DIR)/Carthage/Build/",
 				);
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3678,7 +3699,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3704,7 +3728,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3731,7 +3758,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoPythia;
@@ -3812,7 +3842,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3838,7 +3871,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3865,7 +3901,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3917,7 +3956,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4000,7 +4042,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4027,7 +4072,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoRatchet;
@@ -4052,7 +4100,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+					"$(PROJECT_DIR)/Carthage/Build/",
 				);
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -4080,7 +4128,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4161,7 +4212,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4224,7 +4278,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilCryptoPythia;
@@ -4266,7 +4323,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/",
+				);
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/VirgilCryptoWrapper.xcodeproj/project.pbxproj
+++ b/VirgilCryptoWrapper.xcodeproj/project.pbxproj
@@ -526,6 +526,10 @@
 		970F4DB8269DEA7D002C8008 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */; };
 		970F4DBA269DEA7D002C8008 /* VSCRatchet.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4DAB269DEA44002C8008 /* VSCRatchet.xcframework */; };
 		9729286415B54C309EF1AB9F4FEC0A3D /* PasswordRecipientInfoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D60A873FF0B6BB9A0715C3BEA9CFDA /* PasswordRecipientInfoList.swift */; };
+		9796B927269F44DC009D44DD /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */; };
+		9796B92A269F44E5009D44DD /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */; };
+		9796B92D269F44EB009D44DD /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */; };
+		9796B930269F44F2009D44DD /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */; };
 		98449A3F2C909CC084593F79095ECAD5 /* RatchetCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224EF7201F02DA8006518718FCF5AE98 /* RatchetCommon.swift */; };
 		993E26D7B281D8EB50AB352477425616 /* VirgilCryptoRatchet.h in Headers */ = {isa = PBXBuildFile; fileRef = 960B2A8CA6579C15E842054EB2AEFC25 /* VirgilCryptoRatchet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9AED3C24E5FC92BAD3A5A14CF08059A7 /* KeyDeserializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA58BA1461A32173AF7B416780C64571 /* KeyDeserializer.swift */; };
@@ -1281,6 +1285,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				970F4D96269DE64F002C8008 /* VSCPythia.xcframework in Frameworks */,
+				9796B927269F44DC009D44DD /* VSCCommon.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1289,6 +1294,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				970F4D9C269DE6FB002C8008 /* VSCPythia.xcframework in Frameworks */,
+				9796B92A269F44E5009D44DD /* VSCCommon.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1346,6 +1352,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				970F4DA5269DEA19002C8008 /* VSCPythia.xcframework in Frameworks */,
+				9796B930269F44F2009D44DD /* VSCCommon.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1433,6 +1440,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				970F4DA2269DE7B6002C8008 /* VSCPythia.xcframework in Frameworks */,
+				9796B92D269F44EB009D44DD /* VSCCommon.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VirgilCryptoWrapper.xcodeproj/project.pbxproj
+++ b/VirgilCryptoWrapper.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -86,7 +86,6 @@
 		02A1C01B8BC8470B9D588C68265F9C3A /* Sha384.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240E1F1294051A5761709472EE894B0B /* Sha384.swift */; };
 		02BBB81AE556C1692D0D9E2BF1361E50 /* AuthEncrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F19B083A708F7415861563327B7A5BD /* AuthEncrypt.swift */; };
 		03095F89E24BAC8282E8C0E036870D2D /* RatchetCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224EF7201F02DA8006518718FCF5AE98 /* RatchetCommon.swift */; };
-		030C4C4CD90BDC0DAC2E80B7DA24F420 /* VSCRatchet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77867337B494EFBE8F79FC34CC180D30 /* VSCRatchet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		03AAAD9826E4BF6F8BFAD37E4DD49898 /* GroupMsgType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1BFBD5C27A440CDE84FDC3429B688F /* GroupMsgType.swift */; };
 		0562A6B743810E3CA037C42B7EAE14BD /* PythiaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000E6CDB580C8BC963B269A7B6390C03 /* PythiaError.swift */; };
 		058BC1105253C48291A2EEAA286D7040 /* VirgilCryptoFoundationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE63F42C8EC4586AAEE1780EB35CB8E /* VirgilCryptoFoundationTests.swift */; };
@@ -96,13 +95,11 @@
 		073292DFA417B14681C07F92496E1954 /* MsgType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D6BD151622E4C6BFFD3E707F2990D7 /* MsgType.swift */; };
 		08661115C21F2986E67A3B618985E34E /* AlgInfoDeserializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FEE48513124E4C5529203AE5A9D845 /* AlgInfoDeserializer.swift */; };
 		098047D31133547BA3059AFAC32FEF4B /* VirgilCryptoFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E93548B6D2AB5A90DC746D77B78ACD66 /* VirgilCryptoFoundation.framework */; };
-		09A19CF241C4E8FFBBD3E934C0E6124A /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD351D1532C9F158A4CF27C7ADAC4BE /* VSCFoundation.framework */; };
 		0A7264580E1EA5E23A6C26FE8A620EAB /* OidId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44305C4FD16F206D77A3D48C90DDA2AA /* OidId.swift */; };
 		0AFB32E25AE453F4B70D13BEAE343CF6 /* EntropyAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B968E6F792275C59C2536A92206C75 /* EntropyAccumulator.swift */; };
 		0B008A0CD48C41D1D5CD59D626A55A9C /* Hkdf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912DB40A57D33B496EECEB012E3A0144 /* Hkdf.swift */; };
 		0B1A5932977C8A6FC9D1C94F4199F29C /* HashBasedAlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91487494B4B6FC9BEC58BAF9DDE0FB32 /* HashBasedAlgInfo.swift */; };
 		0B5E9DE27F0C8BAEE745A3AE7026E411 /* Aes256Gcm.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD16AF1719F26A9AEA4089BA01087C7 /* Aes256Gcm.swift */; };
-		0CAE819BFCEB33F16575E174D1AA9AD7 /* VSCRatchet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 365C842CBC8A18274C4C1B3418914C40 /* VSCRatchet.framework */; };
 		0DD138A7F4D37584A766E81B20EB08AD /* AlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BCC4C91E6AFC6DE04006B510D526FE /* AlgInfo.swift */; };
 		0E1F9523CFBFD2EB559938961A89BA64 /* PrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D950A91C786D452ACC8DD249C2898718 /* PrivateKey.swift */; };
 		0EE5D1E2C36E8462BB6B80723692D1A0 /* AuthDecrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4726B96CDF5C6915ED200737DBDC4F4 /* AuthDecrypt.swift */; };
@@ -110,9 +107,7 @@
 		0F512D6AC4809691D4AFC88236FAF6C7 /* AuthEncrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F19B083A708F7415861563327B7A5BD /* AuthEncrypt.swift */; };
 		101EF3D941008D7D17FA8DA7916009C5 /* VSCPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E2CD4D12B41E25AACF6794F252A7B0E /* VSCPythia.framework */; };
 		10B00E92BC70249B16E92FBC395F7EF8 /* AuthDecrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4726B96CDF5C6915ED200737DBDC4F4 /* AuthDecrypt.swift */; };
-		10CAA044E1B5C6322BCDDAB98D8E3F8C /* VSCCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 537CDB0ED8D5DABCFE2505653C41F36D /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		115304D69BE19B609A213AB28FBE77F9 /* Hash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D102052E4F23C740AC3DACF001DAEE /* Hash.swift */; };
-		117C7DD7C3B719ABD7DADC155685EE67 /* VSCRatchet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EBC06F0AFEE4145AB076E3CBE7993685 /* VSCRatchet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		118DC7BD120F5AF7756E6A0682600902 /* VirgilCryptoPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77509BE765338E7E1FE8993816F190B4 /* VirgilCryptoPythia.framework */; };
 		11953C0B922C847594732A68DBF86924 /* PythiaImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A1527400A1A808586AF22E2EA96BB3 /* PythiaImplementation.swift */; };
 		1198B3ED139404AA8D1D346A00D14945 /* MessageInfoCustomParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1829A5096E0A995DC17D93D98B74F7 /* MessageInfoCustomParams.swift */; };
@@ -136,7 +131,6 @@
 		1996E9FB648E71088D1866B01C90F43A /* Ecies.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDDF060DC68D9B7D08370DB258BE39D /* Ecies.swift */; };
 		19AE0292EE5BCFF59FF379D7ECC9BB9B /* VirgilCryptoRatchetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA7A9731601B4E6D95E64FF4D96910E /* VirgilCryptoRatchetTests.swift */; };
 		19E965AB80F7444425A2F55E67398A1B /* PublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D29982AC13070BAA09227353BE74E3 /* PublicKey.swift */; };
-		1CA424BC19CA8FB632B7EFB782BD6267 /* VSCPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E2CD4D12B41E25AACF6794F252A7B0E /* VSCPythia.framework */; };
 		1DCE41EC3291012DB07C460CACD0F783 /* CContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F43EFEDC6B22D5E53F40689E35BF69 /* CContext.swift */; };
 		1E0E3859F7D370E346FD0CC4BD86FE78 /* FoundationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E33EF6EE07EC571FC56AF62B1FE11064 /* FoundationError.swift */; };
 		1F2624EAD67E689FCDF62985092E51D6 /* Signer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED3E4F895B8722D6A3F52C81B66AF36 /* Signer.swift */; };
@@ -146,10 +140,8 @@
 		21A8E3359A4C3EE620DD7E736E84A0DC /* AlgFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CED32CE3C5B64E72A60626CBB24C73 /* AlgFactory.swift */; };
 		225D92CD80CBD0C77EE4E4B0AE63CEB8 /* VirgilCryptoFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 540D410964789DEC990D0534DB6BFCEC /* VirgilCryptoFoundation.framework */; };
 		22E929A42DD747A9E0BA3A5941851B74 /* EntropySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2CEF1A1BF6F82A3371CBB57A46F17C /* EntropySource.swift */; };
-		2371C578979B36EE1E8534413D006CC9 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E747C06C35F7243875CD0BE5309A89F1 /* VSCFoundation.framework */; };
 		2453EEF991A569F166E3007E8360EFCC /* Pkcs5Pbes2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4D8A16766C93FB352971B36798590A /* Pkcs5Pbes2.swift */; };
 		2491AD87807124026382D9E9B0823193 /* Pkcs5Pbkdf2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62060792CBE0D3DCF19F4E70C2909324 /* Pkcs5Pbkdf2.swift */; };
-		259FD5D74D04B068843D9D21A8515653 /* VSCRatchet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5785DE1D99EAE191C625E2A5E3EC218 /* VSCRatchet.framework */; };
 		276F2B74198343F2F3A2B365B7DD13A1 /* FoundationImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B930DF9FC7AB5E513FCCD5F0D431AA58 /* FoundationImplementation.swift */; };
 		27B29ED0D718628F30407B64FEDAA194 /* RatchetImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7C17011799B7D8643BEAD6D8EF9B4F /* RatchetImplementation.swift */; };
 		27F6B8B82E9A5D5B8E53F75EC50A8A14 /* MessageInfoCustomParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1829A5096E0A995DC17D93D98B74F7 /* MessageInfoCustomParams.swift */; };
@@ -169,7 +161,6 @@
 		30C2100C675469FE47F07EF1E1052D5F /* Encrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FFFC641D9BD9BEF886696C4D65311C /* Encrypt.swift */; };
 		3135B68D9FB07DEBE82257F570B4ABB1 /* VirgilCryptoFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = A84AA161461F5FC6437DDF90B88103D1 /* VirgilCryptoFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32F677E9012E2C3CF2552478CCE65AAE /* Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6196A4ACC9E0049AA243D5A901211B6C /* Key.swift */; };
-		3374B56E7338F5D9053F889654046FDF /* VSCCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B0B76A1F472095E79D5A2EED014ACFDF /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		33B0D0B4C996F4E5ACE4477FA09E743B /* CContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9E208539664B88E540699711A6E096 /* CContext.swift */; };
 		340B95452DCAF3BB14E0AA1B35444DCA /* RsaPrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947D25545BAB9EAE23DB13A7BAE3DCD4 /* RsaPrivateKey.swift */; };
 		34149DA0B76B64C73DA335AF9C854FF1 /* VSCRatchet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77867337B494EFBE8F79FC34CC180D30 /* VSCRatchet.framework */; };
@@ -376,14 +367,12 @@
 		45B51FF3D55149158ABF1B09B97ED186 /* AlgId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E115D5E7608BA04C612929B276744B /* AlgId.swift */; };
 		45C662F4A8431AD2F0F5C4CF5C8AF9E0 /* Kdf1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C3AD30F43BC723714B4134AC5D0312E /* Kdf1.swift */; };
 		45D6D7D3D7D96B02CA150D9FDD1C5746 /* VirgilCryptoRatchet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0292852769279B468EDD1C02C429DEB2 /* VirgilCryptoRatchet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4648D501D76819A15E7D7F26C1F136DB /* VSCCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 537CDB0ED8D5DABCFE2505653C41F36D /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		46AECF573B2F85E93985CA2AA15A8A9B /* AlgInfoSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA19916DFD333F0BFD9DB7940A3B6E2 /* AlgInfoSerializer.swift */; };
 		46B5AA1732672954C0EAEC6286E117FD /* KeyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C678030818AB5850A641960BF79F298 /* KeyProvider.swift */; };
 		471C0F03E9ABC4D2B8E65CC328335AF9 /* MessageInfoCustomParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1829A5096E0A995DC17D93D98B74F7 /* MessageInfoCustomParams.swift */; };
 		47C1D7C3E05C0BBB2C8BA32DEC072FB1 /* Mac.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16BADA7343F0DCDBEF1CA2B35262AE3 /* Mac.swift */; };
 		48E64C3B0B43DC8B1531597A7161927A /* EntropyAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B968E6F792275C59C2536A92206C75 /* EntropyAccumulator.swift */; };
 		498857DD133A49A7BEDD5B86AF8D5ECE /* GroupMsgType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1BFBD5C27A440CDE84FDC3429B688F /* GroupMsgType.swift */; };
-		498A9D47A06B0A2D0EC19E1E3DBFC54C /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAEC40A65CDF21E4D0F755C5B23998A0 /* VSCFoundation.framework */; };
 		49C4F23728464BCA656311BD86DC1014 /* Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE18690AC37D7164CA87647800DD458 /* Base64.swift */; };
 		4A9203AB9256E4357D4D20C194388E38 /* CipherAlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2C71ED044C93EB7A1580D691AFA296 /* CipherAlgInfo.swift */; };
 		4B6358000E703A8CD6F979BC244BA976 /* SeedEntropySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F78EAE618D85485C12A1105C6E45F45 /* SeedEntropySource.swift */; };
@@ -396,7 +385,6 @@
 		4F20D969FEC192F08E1FACBD91B0551B /* MessageInfoDerSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A092E1ED9E39C5D4EC2FE9CC3A063D2 /* MessageInfoDerSerializer.swift */; };
 		508CC1CF407625AE0E4456E63F15A1DC /* CipherAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A1719D816EEC31A8E3BD697F440B24 /* CipherAuth.swift */; };
 		50B98CCB739E61C18F9FD71D948F6504 /* AuthDecrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4726B96CDF5C6915ED200737DBDC4F4 /* AuthDecrypt.swift */; };
-		51B69D579B7C01856DBD8A0F9F3BFFA3 /* VSCPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06470D5BE69DEF133DCDD2E55F856BCA /* VSCPythia.framework */; };
 		527759E56E63440B4CD8467F0C0AB192 /* MessageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD396FEFADA2E89793ED6C34D0415CC /* MessageInfo.swift */; };
 		52A5D9EBACD41BAC284AD7632C4949A2 /* AuthEncrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F19B083A708F7415861563327B7A5BD /* AuthEncrypt.swift */; };
 		53EE4762CC759D5200383A64B30E080A /* Hash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D102052E4F23C740AC3DACF001DAEE /* Hash.swift */; };
@@ -407,10 +395,8 @@
 		56914B35E06D15D3A7130D0A223F178D /* Asn1Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B460B409AD44E59A332D9CCB6E55C91C /* Asn1Writer.swift */; };
 		570B6C8B5F4C279F8A496FAA3C34F303 /* RatchetSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830979EB33504F633A6D4D34B56E3D25 /* RatchetSession.swift */; };
 		5710CF2E3F42473A37D8EFB6D3611F40 /* EntropyAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B968E6F792275C59C2536A92206C75 /* EntropyAccumulator.swift */; };
-		5736A733CFF662C3ACBDB4548C8D02B4 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD0D8A1BA3F0E2C279D0AD1D7745FAA4 /* VSCFoundation.framework */; };
 		580EAF2B9ADC79B369D9124902129D04 /* MessageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD396FEFADA2E89793ED6C34D0415CC /* MessageInfo.swift */; };
 		5844AD06EF62D573B553C138B88CCD1A /* Pkcs8Serializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD23178A0DF5146BBE23C690E02B878D /* Pkcs8Serializer.swift */; };
-		58FFC6C7C290031036D1940B0FDF328F /* VSCCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B426F3F94950B498F305E418AEB9D7E2 /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5996C569F2837402F2905EF13D63A6E4 /* FakeRandom.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C584EA6CF4776627D883CD7AAB334C /* FakeRandom.swift */; };
 		59E348617FA5E81C4F6C55AF53A3F6AD /* AlgInfoSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA19916DFD333F0BFD9DB7940A3B6E2 /* AlgInfoSerializer.swift */; };
 		5A27DE94651066D438EB8EA6A0E9449C /* CContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9E208539664B88E540699711A6E096 /* CContext.swift */; };
@@ -418,7 +404,6 @@
 		5AC1BAABF65656260BA8304079BAEFEA /* MsgType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D6BD151622E4C6BFFD3E707F2990D7 /* MsgType.swift */; };
 		5B60DFAB44771CECF8B6369FB0B20222 /* OidId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44305C4FD16F206D77A3D48C90DDA2AA /* OidId.swift */; };
 		5BAB2202172CA2BE3989D7DB9C664B35 /* SaltedKdfAlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F817756736497E56BC6B1F7BC86CC834 /* SaltedKdfAlgInfo.swift */; };
-		5BB17807806F87EC7F8F3055D2EAEC33 /* VSCRatchet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F5785DE1D99EAE191C625E2A5E3EC218 /* VSCRatchet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5D09B7CC6B517F90E21B3190FF6E89A4 /* Mac.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16BADA7343F0DCDBEF1CA2B35262AE3 /* Mac.swift */; };
 		5D0D8D9EE76E928587141B9E140B76F7 /* Asn1Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5F298F35294FDCBF07392FF5F82F8A /* Asn1Tag.swift */; };
 		5D7EAA036C9F04EBC516CABF44AA6EA8 /* AlgInfoDerDeserializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8F0A56151F1BFEBF9FCC905AEB9F0A /* AlgInfoDerDeserializer.swift */; };
@@ -439,7 +424,6 @@
 		65233FD6C2D2AD88A8441883447B8D57 /* PythiaImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A1527400A1A808586AF22E2EA96BB3 /* PythiaImplementation.swift */; };
 		65639C5D0D183118BAAAC41A932C84B4 /* Hash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D102052E4F23C740AC3DACF001DAEE /* Hash.swift */; };
 		659272750278DAEEB32F9112991DB8D4 /* VirgilCryptoFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3A9C2C91D7CA038771E57A3E4EE8DE2 /* VirgilCryptoFoundation.framework */; };
-		6593236B2B1F6E82DD603AF0371F585E /* VSCCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 537CDB0ED8D5DABCFE2505653C41F36D /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		66F13C85AE7B9A44E7958CE983F1E73E /* CContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F43EFEDC6B22D5E53F40689E35BF69 /* CContext.swift */; };
 		67157A0CF3DADB275F029DE552DCA146 /* VSCCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B426F3F94950B498F305E418AEB9D7E2 /* VSCCommon.framework */; };
 		6853A5970F8A3116335EFCEE0E4A3D01 /* SaltedKdf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F319464E90A5470062CB9A4B7CAEC45 /* SaltedKdf.swift */; };
@@ -476,7 +460,6 @@
 		7BF34A10228CEF865CBF5203E961EB30 /* ComputeSharedKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65BD06E323EE4B9204614ADD0077EEA /* ComputeSharedKey.swift */; };
 		7C6454D6A6EB364DAEBEE11A9DFBD095 /* PythiaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000E6CDB580C8BC963B269A7B6390C03 /* PythiaError.swift */; };
 		7C86CEF331C30DC0AE660C087F78E1ED /* RatchetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EC631B558BF525EF74AEB25C02E086 /* RatchetError.swift */; };
-		7C9A133E264E0ADD79A617D9EBA91305 /* VSCCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B426F3F94950B498F305E418AEB9D7E2 /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7CC7CAF03F2303F3156603A6D37286B0 /* AlgFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CED32CE3C5B64E72A60626CBB24C73 /* AlgFactory.swift */; };
 		7DBF9585664C51CD1542B3C5D19A8B7D /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FA63831F89CEA0AD98B932A0943D25 /* Cipher.swift */; };
 		7DE3585602D0C17DDB4A950705815563 /* Pkcs5Pbes2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4D8A16766C93FB352971B36798590A /* Pkcs5Pbes2.swift */; };
@@ -486,13 +469,11 @@
 		7F87DF168DCF4131EA159878EB283269 /* KeySerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F4F719F320FD2AE3BE8F859DE6E49D /* KeySerializer.swift */; };
 		7FBFF602E167C9FF1497FE8FB5592F6E /* VirgilCryptoPythiaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D54AC7B7508AD4A0B706665C11DCA0 /* VirgilCryptoPythiaTests.swift */; };
 		81AB5A2C149DE98BB3FD7C7931645E08 /* AlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BCC4C91E6AFC6DE04006B510D526FE /* AlgInfo.swift */; };
-		82AFE5FD529DE832A98EE6D78D1D4FBC /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E747C06C35F7243875CD0BE5309A89F1 /* VSCFoundation.framework */; };
 		82F6AB9BBF7F964A5EF314D691C79464 /* AlgInfoDerSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E38864E8766F048DCA6759537368FE /* AlgInfoDerSerializer.swift */; };
 		83CDC1112B55F53CB96F786A9094AE12 /* Asn1Reader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605C1FA7C04B4C1299CEE8B5473B734C /* Asn1Reader.swift */; };
 		84AF42AA727039B7423C7E888F92F8B4 /* PythiaImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A1527400A1A808586AF22E2EA96BB3 /* PythiaImplementation.swift */; };
 		84BE22161B93257BC030BBC84FDFE287 /* MessageInfoSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC33983AF5F67C443D9317C4CC93AF1 /* MessageInfoSerializer.swift */; };
 		84E1BBD1D086B0D74BF448B72496DB5C /* Sha224.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA44AA37F558B58EDB7BCAB9F7EE5EC /* Sha224.swift */; };
-		851219C1D937512C0AEAAD8C512BEE50 /* VSCFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E747C06C35F7243875CD0BE5309A89F1 /* VSCFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		851DD45384A3058E6A95C147472FD718 /* KeyDeserializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA58BA1461A32173AF7B416780C64571 /* KeyDeserializer.swift */; };
 		8523FF69994CA6991283FDFE50CD177E /* CipherAuthInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AE8F552F4D6124ADC8221959761840 /* CipherAuthInfo.swift */; };
 		86216C629915A59FE2830F0D3171CA8A /* FoundationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E33EF6EE07EC571FC56AF62B1FE11064 /* FoundationError.swift */; };
@@ -510,7 +491,6 @@
 		8AC416E94313B24ECD2BF7797EBF12A7 /* Hash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D102052E4F23C740AC3DACF001DAEE /* Hash.swift */; };
 		8AE98643A22AEE72D99762A0A8053CD5 /* MsgType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D6BD151622E4C6BFFD3E707F2990D7 /* MsgType.swift */; };
 		8B4EB523C1AEB406F9AF005DA9751F7A /* VirgilCryptoFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0331CA4A8409F2A8382D3C060B88C880 /* VirgilCryptoFoundation.framework */; };
-		8BBBD70EA3C087EF4E2C8017167268DF /* VSCFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AAEC40A65CDF21E4D0F755C5B23998A0 /* VSCFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8BE1E2556A17FF3485AC58654D21E1F2 /* MessageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD396FEFADA2E89793ED6C34D0415CC /* MessageInfo.swift */; };
 		8C0EDACD87C60DC03CD6B16F29EA088E /* Mac.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16BADA7343F0DCDBEF1CA2B35262AE3 /* Mac.swift */; };
 		8CBACAE95B745253E96721E0CB495B8A /* PbeAlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6486DF9EE06E63B264CF3F29B3228A07 /* PbeAlgInfo.swift */; };
@@ -525,9 +505,28 @@
 		9496B013B5B5EEC2720BAACDFDD394F8 /* VirgilCryptoRatchet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 36422389DE602618D07BC081C6E73168 /* VirgilCryptoRatchet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		94B44058B4452AC2C5FC0A72D584565F /* Encrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FFFC641D9BD9BEF886696C4D65311C /* Encrypt.swift */; };
 		95714E12FF0F1FE59804BE023C37DE0D /* CContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9E208539664B88E540699711A6E096 /* CContext.swift */; };
+		970F4D71269DD3EE002C8008 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */; };
+		970F4D74269DD412002C8008 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */; };
+		970F4D77269DD41B002C8008 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */; };
+		970F4D7A269DD41F002C8008 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */; };
+		970F4D84269DE51F002C8008 /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */; };
+		970F4D87269DE525002C8008 /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */; };
+		970F4D8A269DE529002C8008 /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */; };
+		970F4D96269DE64F002C8008 /* VSCPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D95269DE64F002C8008 /* VSCPythia.xcframework */; };
+		970F4D9C269DE6FB002C8008 /* VSCPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D95269DE64F002C8008 /* VSCPythia.xcframework */; };
+		970F4D9F269DE789002C8008 /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */; };
+		970F4DA2269DE7B6002C8008 /* VSCPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D95269DE64F002C8008 /* VSCPythia.xcframework */; };
+		970F4DA5269DEA19002C8008 /* VSCPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D95269DE64F002C8008 /* VSCPythia.xcframework */; };
+		970F4DA8269DEA32002C8008 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */; };
+		970F4DAC269DEA44002C8008 /* VSCRatchet.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4DAB269DEA44002C8008 /* VSCRatchet.xcframework */; };
+		970F4DAE269DEA59002C8008 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */; };
+		970F4DB0269DEA59002C8008 /* VSCRatchet.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4DAB269DEA44002C8008 /* VSCRatchet.xcframework */; };
+		970F4DB3269DEA63002C8008 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */; };
+		970F4DB5269DEA63002C8008 /* VSCRatchet.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4DAB269DEA44002C8008 /* VSCRatchet.xcframework */; };
+		970F4DB8269DEA7D002C8008 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */; };
+		970F4DBA269DEA7D002C8008 /* VSCRatchet.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 970F4DAB269DEA44002C8008 /* VSCRatchet.xcframework */; };
 		9729286415B54C309EF1AB9F4FEC0A3D /* PasswordRecipientInfoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D60A873FF0B6BB9A0715C3BEA9CFDA /* PasswordRecipientInfoList.swift */; };
 		98449A3F2C909CC084593F79095ECAD5 /* RatchetCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224EF7201F02DA8006518718FCF5AE98 /* RatchetCommon.swift */; };
-		993580AC00A97C3A7EE166E2B66FEFF8 /* VSCRatchet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77867337B494EFBE8F79FC34CC180D30 /* VSCRatchet.framework */; };
 		993E26D7B281D8EB50AB352477425616 /* VirgilCryptoRatchet.h in Headers */ = {isa = PBXBuildFile; fileRef = 960B2A8CA6579C15E842054EB2AEFC25 /* VirgilCryptoRatchet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9AED3C24E5FC92BAD3A5A14CF08059A7 /* KeyDeserializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA58BA1461A32173AF7B416780C64571 /* KeyDeserializer.swift */; };
 		9B972CE635F8C81325C146BCBDAB3F81 /* RsaPublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = F67C7A6574E3B3894D4B666690055623 /* RsaPublicKey.swift */; };
@@ -570,7 +569,6 @@
 		ADD08CE63381C6C8CAB2E2A6F762A4BE /* Hkdf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912DB40A57D33B496EECEB012E3A0144 /* Hkdf.swift */; };
 		AE1ED8F771C25313DEC5928FD6C24EB7 /* Hmac.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9445FE204BE3DA08C90E85A11A58CC59 /* Hmac.swift */; };
 		AE317AB8792C9CA25CA34826E781A53E /* RecipientCipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D450BCC1E7751BB381B514EB1558BAFD /* RecipientCipher.swift */; };
-		AE9AAF6FC527DD596807B2D98F5187EA /* VSCFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E747C06C35F7243875CD0BE5309A89F1 /* VSCFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AF148A3C56BEA147FE38006E2AC5FF02 /* Asn1Reader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605C1FA7C04B4C1299CEE8B5473B734C /* Asn1Reader.swift */; };
 		AFC7BD01367BDA2F41B053DE8E03A6F3 /* Encrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FFFC641D9BD9BEF886696C4D65311C /* Encrypt.swift */; };
 		AFF1B4E455E38486C3C6668F18DFABAA /* Sha256.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3E6D413B6984E4A16125D4D678AC9D /* Sha256.swift */; };
@@ -582,7 +580,6 @@
 		B2D41F9ED0E792F978AFE830EDFEB1CB /* PythiaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000E6CDB580C8BC963B269A7B6390C03 /* PythiaError.swift */; };
 		B2EC19548AD002CD5871C4789F80D190 /* AlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BCC4C91E6AFC6DE04006B510D526FE /* AlgInfo.swift */; };
 		B2FCF821267AF92C4732142BB41252D5 /* Aes256Gcm.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD16AF1719F26A9AEA4089BA01087C7 /* Aes256Gcm.swift */; };
-		B3EAAB90A9A4EAD6CD047C38246E77A7 /* VSCFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AAEC40A65CDF21E4D0F755C5B23998A0 /* VSCFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B43FF091B27894A200B8723FBBBC740B /* Kdf1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C3AD30F43BC723714B4134AC5D0312E /* Kdf1.swift */; };
 		B4F0F32E77F4DFA6831376AF40E84268 /* Kdf2.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAA40E13A6DBF6976C2FB8EC9BEB8C5 /* Kdf2.swift */; };
 		B5116C3B69EF5D617D26436BA0C02A5D /* VirgilCryptoPythia.h in Headers */ = {isa = PBXBuildFile; fileRef = 588CB566553A8A8E133D667928419547 /* VirgilCryptoPythia.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -597,13 +594,10 @@
 		B7F1EA967F6829DDE16C8D092BAE8E3D /* VirgilCryptoRatchet.h in Headers */ = {isa = PBXBuildFile; fileRef = 960B2A8CA6579C15E842054EB2AEFC25 /* VirgilCryptoRatchet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B85C04E252EB1C7BEE9641651B431293 /* ComputeSharedKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65BD06E323EE4B9204614ADD0077EEA /* ComputeSharedKey.swift */; };
 		B889D4AA4BC7728774085D90A23472DB /* PrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D950A91C786D452ACC8DD249C2898718 /* PrivateKey.swift */; };
-		B925167DB76FE7C02ECEE7BE0FF7A411 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD351D1532C9F158A4CF27C7ADAC4BE /* VSCFoundation.framework */; };
 		BA8A9FCDAA7FC53C5D0D514B2CB37580 /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FA63831F89CEA0AD98B932A0943D25 /* Cipher.swift */; };
-		BAAA204002A047F20D67F8E2142381E5 /* VSCPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9DB0B09C2B3FD1C78384FEC783FBD3E /* VSCPythia.framework */; };
 		BAD6101A29445F183A7DFC2770F72BE0 /* GroupMsgType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1BFBD5C27A440CDE84FDC3429B688F /* GroupMsgType.swift */; };
 		BB2D95ABCD9D098DA348DDA5FAF21CA6 /* RatchetSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830979EB33504F633A6D4D34B56E3D25 /* RatchetSession.swift */; };
 		BB3EB209D525B9CAC8E3527E3EDB05EE /* PasswordRecipientInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53725F7A0160C664342F8428A403B37 /* PasswordRecipientInfo.swift */; };
-		BC73A89A2A385471B16C3C49A197E686 /* VSCFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD351D1532C9F158A4CF27C7ADAC4BE /* VSCFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BD6A9B0AE382989C2B1B80F1048DF5E9 /* PrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D950A91C786D452ACC8DD249C2898718 /* PrivateKey.swift */; };
 		BDDBEEF7475EBB9162332BDABAD96C56 /* SimpleAlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A4189F841DAB5C3F653FAC33E6BA34 /* SimpleAlgInfo.swift */; };
 		BEC1F63A5D9369091BBA07142D203319 /* AlgFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CED32CE3C5B64E72A60626CBB24C73 /* AlgFactory.swift */; };
@@ -613,20 +607,16 @@
 		C19AABC1370EF1B516CFC7C0C62704EA /* VirgilCryptoFoundationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE63F42C8EC4586AAEE1780EB35CB8E /* VirgilCryptoFoundationTests.swift */; };
 		C32A1664A19453AE2270BD7BE0F49DDD /* Pkcs5Pbkdf2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62060792CBE0D3DCF19F4E70C2909324 /* Pkcs5Pbkdf2.swift */; };
 		C3845B7FB0B0AD5743293945E380E9A2 /* EntropySource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2CEF1A1BF6F82A3371CBB57A46F17C /* EntropySource.swift */; };
-		C40ADAD215700FAAFCA33E9974216CC6 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD0D8A1BA3F0E2C279D0AD1D7745FAA4 /* VSCFoundation.framework */; };
 		C52EF33357885303009973EB9FC55696 /* VSCCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 537CDB0ED8D5DABCFE2505653C41F36D /* VSCCommon.framework */; };
 		C650F27FE68A69F0690098AADAC0BFBF /* Aes256Gcm.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD16AF1719F26A9AEA4089BA01087C7 /* Aes256Gcm.swift */; };
 		C696E2183403A4167971DB99FEDB1B3A /* SaltedKdfAlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F817756736497E56BC6B1F7BC86CC834 /* SaltedKdfAlgInfo.swift */; };
 		C6C42B45A381BD6B0C4DC303717A4CBC /* VirgilCryptoPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AB2DFC92D81F0E4CEAD678E99124B64 /* VirgilCryptoPythia.framework */; };
 		C6EE3411B12E886A01CBB6C7FBE529F7 /* Decrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EB4C19995B40306339E9FC6B80B63A /* Decrypt.swift */; };
-		C7282F65E5A91B77383C966CDF763508 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAEC40A65CDF21E4D0F755C5B23998A0 /* VSCFoundation.framework */; };
 		C73F1A0C7DB705FF5DCBC89AEEB3C7B8 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E747C06C35F7243875CD0BE5309A89F1 /* VSCFoundation.framework */; };
 		C8EA8408B1327FDA305F6266D6133E06 /* CtrDrbg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 304FCFD06291B1E34E63330D46410BA6 /* CtrDrbg.swift */; };
 		C98AB0876F7AF5A15995CE77F4DD811C /* AlgInfoDeserializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FEE48513124E4C5529203AE5A9D845 /* AlgInfoDeserializer.swift */; };
-		CA99588BF86114A4C771ECD84E93F9E1 /* VSCRatchet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBC06F0AFEE4145AB076E3CBE7993685 /* VSCRatchet.framework */; };
 		CAFA5ED635B54097FEA65CFF52F0F9BA /* VSCCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0B76A1F472095E79D5A2EED014ACFDF /* VSCCommon.framework */; };
 		CB26A682B52A866ADF7D6A777D7887E0 /* Sha512.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5544F6D22233D281C108320344F9A473 /* Sha512.swift */; };
-		CB8894043C91D55C0397878E54A7CF9B /* VSCPythia.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 06470D5BE69DEF133DCDD2E55F856BCA /* VSCPythia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CB9160D54F90997205482E271AE6AC32 /* CContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3912F3040F1CBC7B4AC578CECE674FF /* CContext.swift */; };
 		CBA965EC55BB386E98BE1560E4EAB113 /* RatchetCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224EF7201F02DA8006518718FCF5AE98 /* RatchetCommon.swift */; };
 		CC6D7A4F652A8062F944640A33AB9AD4 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E747C06C35F7243875CD0BE5309A89F1 /* VSCFoundation.framework */; };
@@ -634,14 +624,12 @@
 		CDC1D7EE58A0C5C3AE3408A143A58C58 /* Verifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD6C38B0BD37C101E8B0822435165A4 /* Verifier.swift */; };
 		CE11BC8768B5CB5ADA61765BB8877B33 /* Decrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EB4C19995B40306339E9FC6B80B63A /* Decrypt.swift */; };
 		CF3910AC0C1A0B813C4C2DD7006308C0 /* CipherAlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2C71ED044C93EB7A1580D691AFA296 /* CipherAlgInfo.swift */; };
-		CF57DC1AE88DC36AAB65E72F45CE0A3F /* VSCFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1AD351D1532C9F158A4CF27C7ADAC4BE /* VSCFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D15B846F1143D676A5319A6BB4D3F145 /* CContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3912F3040F1CBC7B4AC578CECE674FF /* CContext.swift */; };
 		D23877A9F8EA87912ECF4DD515A71304 /* Pem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E063BFD0D569B91795C908DD3CC528B /* Pem.swift */; };
 		D2432862DAB01D388F201F497280A9D6 /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027C23E788FAEFEBA38DF6F531940A2E /* Random.swift */; };
 		D258D4054C029D45A90641AF0528B7D8 /* PbeAlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6486DF9EE06E63B264CF3F29B3228A07 /* PbeAlgInfo.swift */; };
 		D30D695E5E0CF4C65CA82B1461EC379D /* Oid.swift in Sources */ = {isa = PBXBuildFile; fileRef = A108EC7D74A8F34C20C4717A1758DEBF /* Oid.swift */; };
 		D32BDEBD19177A0FFCBC6B89687952A0 /* RatchetImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7C17011799B7D8643BEAD6D8EF9B4F /* RatchetImplementation.swift */; };
-		D334F8A706745E1B46968437F09ED348 /* VSCPythia.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E9DB0B09C2B3FD1C78384FEC783FBD3E /* VSCPythia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D3831F6B9955FC6252402896E5C2833E /* MessageInfoDerSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A092E1ED9E39C5D4EC2FE9CC3A063D2 /* MessageInfoDerSerializer.swift */; };
 		D3BD82AB23BA864F22EF70107D18A309 /* Pythia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C7616A6EA8D692397E4B7CA99C9B2C /* Pythia.swift */; };
 		D489B4B55A716CFA3B6702EE87C1FA3F /* Asn1rd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5595700F701D5B0785592FB98B10F206 /* Asn1rd.swift */; };
@@ -651,7 +639,6 @@
 		D621C68122453DE4733098BB417B3FDA /* KeyRecipientInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E499E731E02A5359719160EE0F08A4C5 /* KeyRecipientInfo.swift */; };
 		D6EB298E6949E3100EB52F4105CB7DB4 /* Kdf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B8A98D3EEA1C0BD1749E4665950D6BF /* Kdf.swift */; };
 		D7CA187C63679E4953D0DC2B69107AA1 /* Alg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951655C3B179DA0EB9B42A8023912B8C /* Alg.swift */; };
-		D7FCD829729A0F09AF8A012A9CAE6C25 /* VSCPythia.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9E2CD4D12B41E25AACF6794F252A7B0E /* VSCPythia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D89483F50CF176140856B09635491659 /* PasswordRecipientInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53725F7A0160C664342F8428A403B37 /* PasswordRecipientInfo.swift */; };
 		D8CCA23FC5DE5FBA62EAD39FA097AE29 /* KeyRecipientInfoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8669FC2D17C7802506C86A76BBCA6B21 /* KeyRecipientInfoList.swift */; };
 		D8E27341F328364A2A2E54CD04A133C8 /* MessageInfoSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC33983AF5F67C443D9317C4CC93AF1 /* MessageInfoSerializer.swift */; };
@@ -683,7 +670,6 @@
 		EA55F3CEA538FF43BA378E096D1B57A7 /* Signer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED3E4F895B8722D6A3F52C81B66AF36 /* Signer.swift */; };
 		EADEF46D45E60CC3F1429EC2C12DDC05 /* CipherAuthInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AE8F552F4D6124ADC8221959761840 /* CipherAuthInfo.swift */; };
 		EB125E0A96626FEFCD60B130DCE8E2DC /* KeySerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F4F719F320FD2AE3BE8F859DE6E49D /* KeySerializer.swift */; };
-		EB3EA2C05E592A7F4A5249ABE4CEA66D /* VSCCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B426F3F94950B498F305E418AEB9D7E2 /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EB8419BE96FD5FA04A5863EF407C6A5B /* Asn1Reader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605C1FA7C04B4C1299CEE8B5473B734C /* Asn1Reader.swift */; };
 		EC796F5C78E468108AE3631BE9C1D254 /* Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6196A4ACC9E0049AA243D5A901211B6C /* Key.swift */; };
 		ECFE335383FBFAEB098FE32E9F29BCE8 /* Hkdf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912DB40A57D33B496EECEB012E3A0144 /* Hkdf.swift */; };
@@ -700,7 +686,6 @@
 		F3462899040140580123334F097C1B15 /* Aes256Cbc.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDC939FBA71F91B8193C4C853E847C1 /* Aes256Cbc.swift */; };
 		F353E18B55FB90927F4E017A00A50A5C /* Asn1Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B460B409AD44E59A332D9CCB6E55C91C /* Asn1Writer.swift */; };
 		F44510732BE02833A8011CBA66D3EC85 /* SimpleAlgInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A4189F841DAB5C3F653FAC33E6BA34 /* SimpleAlgInfo.swift */; };
-		F46134A898545538B4B549B812D8C824 /* VSCCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B0B76A1F472095E79D5A2EED014ACFDF /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F46CC33A05183C2F03B0C99386FB5FB2 /* AlgFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CED32CE3C5B64E72A60626CBB24C73 /* AlgFactory.swift */; };
 		F571F9D52061888658EBB4245D08B4A2 /* VirgilCryptoPythia.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 77509BE765338E7E1FE8993816F190B4 /* VirgilCryptoPythia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F58E1E2C0AACF1DC4500C9E8BEFE4664 /* VirgilCryptoRatchet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A663C0E1090353CE782ADF6F346AEB03 /* VirgilCryptoRatchet.framework */; };
@@ -712,10 +697,8 @@
 		F850D863C88F276B133D938B1B673146 /* CipherAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A1719D816EEC31A8E3BD697F440B24 /* CipherAuth.swift */; };
 		F8BB1C48341E5A5AA05396799B15B3BF /* Sha256.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3E6D413B6984E4A16125D4D678AC9D /* Sha256.swift */; };
 		F8EB39CE97198A1C56D4252B4763B892 /* Sha512.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5544F6D22233D281C108320344F9A473 /* Sha512.swift */; };
-		F8F8567FF7559A2DB51A7E3499B0D5C4 /* VSCPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1C3E08A937A00F8606D8ACFB3B43920 /* VSCPythia.framework */; };
 		F9340AD7C009D53CF44F46383ADE9024 /* VirgilCryptoFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E93548B6D2AB5A90DC746D77B78ACD66 /* VirgilCryptoFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F983E0D30123FCF1BAD5CA8F5BD7E19A /* Asn1wr.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F999E0EA724BF0B98D98D3E7AC99511 /* Asn1wr.swift */; };
-		F9A6BF645C33A16DFCEA187524311929 /* VSCCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B0B76A1F472095E79D5A2EED014ACFDF /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F9DD11CF542A78B4CEE8275A446C22B6 /* RatchetSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830979EB33504F633A6D4D34B56E3D25 /* RatchetSession.swift */; };
 		FBEC9BCDDFEC08AFC38B0151166C1B29 /* KeyRecipientInfoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8669FC2D17C7802506C86A76BBCA6B21 /* KeyRecipientInfoList.swift */; };
 		FBEE6CE3737ADBA33119377B29B0EF60 /* SaltedKdf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F319464E90A5470062CB9A4B7CAEC45 /* SaltedKdf.swift */; };
@@ -961,9 +944,6 @@
 			files = (
 				F9340AD7C009D53CF44F46383ADE9024 /* VirgilCryptoFoundation.framework in Embed Frameworks */,
 				211B885894630B5EF4EC3756E59EF57D /* VirgilCryptoRatchet.framework in Embed Frameworks */,
-				58FFC6C7C290031036D1940B0FDF328F /* VSCCommon.framework in Embed Frameworks */,
-				BC73A89A2A385471B16C3C49A197E686 /* VSCFoundation.framework in Embed Frameworks */,
-				030C4C4CD90BDC0DAC2E80B7DA24F420 /* VSCRatchet.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -975,8 +955,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				5F2927A95F1678281E228BB32AB430C2 /* VirgilCryptoFoundation.framework in Embed Frameworks */,
-				4648D501D76819A15E7D7F26C1F136DB /* VSCCommon.framework in Embed Frameworks */,
-				AE9AAF6FC527DD596807B2D98F5187EA /* VSCFoundation.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -988,8 +966,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				F571F9D52061888658EBB4245D08B4A2 /* VirgilCryptoPythia.framework in Embed Frameworks */,
-				3374B56E7338F5D9053F889654046FDF /* VSCCommon.framework in Embed Frameworks */,
-				D7FCD829729A0F09AF8A012A9CAE6C25 /* VSCPythia.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1002,9 +978,6 @@
 			files = (
 				9FF3E4D4B4D818AEBE532A60011D0839 /* VirgilCryptoFoundation.framework in Embed Frameworks */,
 				45D6D7D3D7D96B02CA150D9FDD1C5746 /* VirgilCryptoRatchet.framework in Embed Frameworks */,
-				6593236B2B1F6E82DD603AF0371F585E /* VSCCommon.framework in Embed Frameworks */,
-				851219C1D937512C0AEAAD8C512BEE50 /* VSCFoundation.framework in Embed Frameworks */,
-				117C7DD7C3B719ABD7DADC155685EE67 /* VSCRatchet.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1016,8 +989,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				2853E10770FCDD95F715973D68E37A51 /* VirgilCryptoPythia.framework in Embed Frameworks */,
-				EB3EA2C05E592A7F4A5249ABE4CEA66D /* VSCCommon.framework in Embed Frameworks */,
-				CB8894043C91D55C0397878E54A7CF9B /* VSCPythia.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1029,8 +1000,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				ABADE34727D5A683D367DBA655EF7F9A /* VirgilCryptoFoundation.framework in Embed Frameworks */,
-				7C9A133E264E0ADD79A617D9EBA91305 /* VSCCommon.framework in Embed Frameworks */,
-				CF57DC1AE88DC36AAB65E72F45CE0A3F /* VSCFoundation.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1042,8 +1011,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				2D496406DFB55F2C25B8FC0FC92BCF84 /* VirgilCryptoFoundation.framework in Embed Frameworks */,
-				F9A6BF645C33A16DFCEA187524311929 /* VSCCommon.framework in Embed Frameworks */,
-				8BBBD70EA3C087EF4E2C8017167268DF /* VSCFoundation.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1056,9 +1023,6 @@
 			files = (
 				E5E421D0A03092685C671609F2555141 /* VirgilCryptoFoundation.framework in Embed Frameworks */,
 				9496B013B5B5EEC2720BAACDFDD394F8 /* VirgilCryptoRatchet.framework in Embed Frameworks */,
-				F46134A898545538B4B549B812D8C824 /* VSCCommon.framework in Embed Frameworks */,
-				B3EAAB90A9A4EAD6CD047C38246E77A7 /* VSCFoundation.framework in Embed Frameworks */,
-				5BB17807806F87EC7F8F3055D2EAEC33 /* VSCRatchet.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1070,8 +1034,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				A73120DA78A9D2628C5456B98C5D5F2C /* VirgilCryptoPythia.framework in Embed Frameworks */,
-				10CAA044E1B5C6322BCDDAB98D8E3F8C /* VSCCommon.framework in Embed Frameworks */,
-				D334F8A706745E1B46968437F09ED348 /* VSCPythia.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1209,6 +1171,10 @@
 		947D25545BAB9EAE23DB13A7BAE3DCD4 /* RsaPrivateKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RsaPrivateKey.swift; sourceTree = "<group>"; };
 		951655C3B179DA0EB9B42A8023912B8C /* Alg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alg.swift; sourceTree = "<group>"; };
 		960B2A8CA6579C15E842054EB2AEFC25 /* VirgilCryptoRatchet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VirgilCryptoRatchet.h; sourceTree = "<group>"; };
+		970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VSCFoundation.xcframework; path = Carthage/Build/VSCFoundation.xcframework; sourceTree = "<group>"; };
+		970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VSCCommon.xcframework; path = Carthage/Build/VSCCommon.xcframework; sourceTree = "<group>"; };
+		970F4D95269DE64F002C8008 /* VSCPythia.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VSCPythia.xcframework; path = Carthage/Build/VSCPythia.xcframework; sourceTree = "<group>"; };
+		970F4DAB269DEA44002C8008 /* VSCRatchet.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VSCRatchet.xcframework; path = Carthage/Build/VSCRatchet.xcframework; sourceTree = "<group>"; };
 		9CAAC5006EFE70CDC79914851F6274F6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9E2CD4D12B41E25AACF6794F252A7B0E /* VSCPythia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = VSCPythia.framework; sourceTree = "<group>"; };
 		9EE38118ECBC048D102B40D29B44D277 /* VirgilCryptoRatchet-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "VirgilCryptoRatchet-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1303,9 +1269,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				498A9D47A06B0A2D0EC19E1E3DBFC54C /* VSCFoundation.framework in Frameworks */,
-				259FD5D74D04B068843D9D21A8515653 /* VSCRatchet.framework in Frameworks */,
 				8667592CB912898E05B8D907F5B3B5C1 /* VirgilCryptoFoundation.framework in Frameworks */,
+				970F4DA8269DEA32002C8008 /* VSCFoundation.xcframework in Frameworks */,
+				970F4DAC269DEA44002C8008 /* VSCRatchet.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1313,7 +1279,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1CA424BC19CA8FB632B7EFB782BD6267 /* VSCPythia.framework in Frameworks */,
+				970F4D96269DE64F002C8008 /* VSCPythia.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1321,7 +1287,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BAAA204002A047F20D67F8E2142381E5 /* VSCPythia.framework in Frameworks */,
+				970F4D9C269DE6FB002C8008 /* VSCPythia.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1329,7 +1295,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5736A733CFF662C3ACBDB4548C8D02B4 /* VSCFoundation.framework in Frameworks */,
+				970F4D7A269DD41F002C8008 /* VSCFoundation.xcframework in Frameworks */,
+				970F4D8A269DE529002C8008 /* VSCCommon.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1337,9 +1304,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2371C578979B36EE1E8534413D006CC9 /* VSCFoundation.framework in Frameworks */,
-				CA99588BF86114A4C771ECD84E93F9E1 /* VSCRatchet.framework in Frameworks */,
 				9CF4CB41444FCD01E9EEB0DEB384D8E8 /* VirgilCryptoFoundation.framework in Frameworks */,
+				970F4DAE269DEA59002C8008 /* VSCFoundation.xcframework in Frameworks */,
+				970F4DB0269DEA59002C8008 /* VSCRatchet.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1367,9 +1334,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C40ADAD215700FAAFCA33E9974216CC6 /* VSCFoundation.framework in Frameworks */,
-				0CAE819BFCEB33F16575E174D1AA9AD7 /* VSCRatchet.framework in Frameworks */,
 				8B4EB523C1AEB406F9AF005DA9751F7A /* VirgilCryptoFoundation.framework in Frameworks */,
+				970F4DBA269DEA7D002C8008 /* VSCRatchet.xcframework in Frameworks */,
+				970F4DB8269DEA7D002C8008 /* VSCFoundation.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1377,7 +1344,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F8F8567FF7559A2DB51A7E3499B0D5C4 /* VSCPythia.framework in Frameworks */,
+				970F4DA5269DEA19002C8008 /* VSCPythia.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1395,7 +1362,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C7282F65E5A91B77383C966CDF763508 /* VSCFoundation.framework in Frameworks */,
+				970F4D71269DD3EE002C8008 /* VSCFoundation.xcframework in Frameworks */,
+				970F4D9F269DE789002C8008 /* VSCCommon.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1403,9 +1371,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B925167DB76FE7C02ECEE7BE0FF7A411 /* VSCFoundation.framework in Frameworks */,
-				993580AC00A97C3A7EE166E2B66FEFF8 /* VSCRatchet.framework in Frameworks */,
 				098047D31133547BA3059AFAC32FEF4B /* VirgilCryptoFoundation.framework in Frameworks */,
+				970F4DB3269DEA63002C8008 /* VSCFoundation.xcframework in Frameworks */,
+				970F4DB5269DEA63002C8008 /* VSCRatchet.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1435,7 +1403,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82AFE5FD529DE832A98EE6D78D1D4FBC /* VSCFoundation.framework in Frameworks */,
+				970F4D74269DD412002C8008 /* VSCFoundation.xcframework in Frameworks */,
+				970F4D84269DE51F002C8008 /* VSCCommon.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1453,7 +1422,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				09A19CF241C4E8FFBBD3E934C0E6124A /* VSCFoundation.framework in Frameworks */,
+				970F4D77269DD41B002C8008 /* VSCFoundation.xcframework in Frameworks */,
+				970F4D87269DE525002C8008 /* VSCCommon.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1461,7 +1431,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				51B69D579B7C01856DBD8A0F9F3BFFA3 /* VSCPythia.framework in Frameworks */,
+				970F4DA2269DE7B6002C8008 /* VSCPythia.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1661,6 +1631,10 @@
 		71F6F543F531F81F040978F95429EF83 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				970F4DAB269DEA44002C8008 /* VSCRatchet.xcframework */,
+				970F4D95269DE64F002C8008 /* VSCPythia.xcframework */,
+				970F4D7D269DD8DB002C8008 /* VSCCommon.xcframework */,
+				970F4D70269DD3EE002C8008 /* VSCFoundation.xcframework */,
 				77B3A846AA34636D0E91FED1FB0C0D9A /* Carthage */,
 			);
 			name = Frameworks;
@@ -3229,10 +3203,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3287,10 +3258,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3317,10 +3285,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3348,10 +3313,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3379,10 +3341,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				MARKETING_VERSION = 0.11.1;
@@ -3401,10 +3360,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3547,10 +3503,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3578,10 +3531,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3644,10 +3594,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoFoundationTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3665,10 +3612,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3741,10 +3685,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3771,10 +3712,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3802,10 +3740,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				MARKETING_VERSION = 0.11.1;
@@ -3823,10 +3758,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoFoundationTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3863,10 +3796,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoFoundationTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3890,10 +3820,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3920,10 +3847,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3951,10 +3875,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3977,10 +3898,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoFoundationTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4009,10 +3927,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4034,10 +3949,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4077,10 +3989,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4103,10 +4012,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4134,10 +4040,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchet/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				MARKETING_VERSION = 0.11.1;
@@ -4192,10 +4095,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4223,10 +4123,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4244,10 +4141,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoRatchetTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4283,10 +4177,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoFoundation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4329,10 +4220,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoFoundationTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4356,10 +4244,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				MARKETING_VERSION = 0.11.1;
@@ -4377,10 +4262,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoFoundationTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4404,10 +4287,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = VirgilCryptoPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
### Added
- Xcode 12.2+ support
- Apple Silicon support

### Project
- Use new format xcframeworks for dependencies
- Added project config
- Bumped up test targets macOS requirement to 10.15.0 (Xcode 12 warnings)

### CI
- Updated to latest Xcode & sdks
- Removed publishing pre-built binaries for Carthage.
(Support for carthage archiving is promised for future release, custom archive doesn't work for multiple frameworks)
- Removed publishing `VirgilCryptoPythia.podspec` & `VirgilCryptoPythia.podspec`
(Cocoapods bug on instant update of master repo)

### Dependencies
- Updated `VSCCrypto` **0.15.2 --> 0.16.0**

### Other
- Updated LICENCE & Copyright